### PR TITLE
fix: legend inside plot, figure 1000x700

### DIFF
--- a/tests/test_local_install.py
+++ b/tests/test_local_install.py
@@ -73,17 +73,11 @@ def main():
     transformed = transform_predefined_processes(df, space_on_x=False)
     print(f"Loaded {len(transformed)} processes")
 
-    p = create_space_time_figure(width=1000, height=700, space_on_x=False)
+    p = create_space_time_figure(width=1200, height=700, space_on_x=False)
     p = add_magnitude_labels(p, font_size="10pt", space_on_x=False)
     p = add_diffusion_lines(p, space_on_x=False)
     p = add_predefined_processes(p, transformed, interactive=False, font_size="9pt", space_on_x=False)
-
-    # Legend inside the plot area, top-left
-    p.legend.location = "top_left"
-    p.legend.click_policy = "hide"
-    p.legend.label_text_font_size = "8pt"
-    p.legend.background_fill_alpha = 0.7
-    p.legend.border_line_alpha = 0.3
+    p = add_legend(p, position="above", font_size="9pt")
     print("Built Stommel diagram OK")
 
     # ── Save embeddable HTML ─────────────────────────────────────────

--- a/tests/test_local_install.py
+++ b/tests/test_local_install.py
@@ -73,11 +73,17 @@ def main():
     transformed = transform_predefined_processes(df, space_on_x=False)
     print(f"Loaded {len(transformed)} processes")
 
-    p = create_space_time_figure(width=1200, height=700, space_on_x=False)
+    p = create_space_time_figure(width=1000, height=700, space_on_x=False)
     p = add_magnitude_labels(p, font_size="10pt", space_on_x=False)
     p = add_diffusion_lines(p, space_on_x=False)
     p = add_predefined_processes(p, transformed, interactive=False, font_size="9pt", space_on_x=False)
-    p = add_legend(p, position="above", font_size="9pt")
+
+    # Legend inside the plot area, top-left
+    p.legend.location = "top_left"
+    p.legend.click_policy = "hide"
+    p.legend.label_text_font_size = "8pt"
+    p.legend.background_fill_alpha = 0.7
+    p.legend.border_line_alpha = 0.3
     print("Built Stommel diagram OK")
 
     # ── Save embeddable HTML ─────────────────────────────────────────

--- a/tests/test_local_install.py
+++ b/tests/test_local_install.py
@@ -77,7 +77,7 @@ def main():
     p = add_magnitude_labels(p, font_size="10pt", space_on_x=False)
     p = add_diffusion_lines(p, space_on_x=False)
     p = add_predefined_processes(p, transformed, interactive=False, font_size="9pt", space_on_x=False)
-    p = add_legend(p, position="above", font_size="9pt")
+    p = add_legend(p, position="right", font_size="9pt")
     print("Built Stommel diagram OK")
 
     # ── Save embeddable HTML ─────────────────────────────────────────


### PR DESCRIPTION
Follows up PR #10.

Iteration log:
- Commit 3a8cde2 — legend moved inside plot (top-left), figure narrowed to 1000px.
- Commit c47e7d5 — restored 1200 width, legend placed above plot.
- Commit 7b75836 — moved legend to right side (original placement).

Net diff vs main: `tests/test_local_install.py` calls `add_legend(p, position="right", font_size="9pt")` instead of using the default 12pt. The 1200×700 figure size from PR #10 is preserved.