### PR TITLE
fix: eliminate BokehUserWarning for range bound 1e21

### DIFF
--- a/plotting.py
+++ b/plotting.py
@@ -95,10 +95,10 @@ def create_space_time_figure(width=1600, height=900, title=" ", space_on_x=True)
     """
     if space_on_x:
         xl, yl = "Space (m\u00b3)", "Time (s)"
-        xr, yr = (10**-27, 10**21), (10**12, 10**-3)
+        xr, yr = (1e-27, 1e21), (1e12, 1e-3)
     else:
         xl, yl = "Time (s)", "Space (m\u00b3)"
-        xr, yr = (10**-3, 10**12), (10**-21, 10**21)
+        xr, yr = (1e-3, 1e12), (1e-21, 1e21)
     p = figure(
         width=width,
         height=height,
@@ -230,7 +230,7 @@ def add_magnitude_labels(p, font_size=DEFAULT_FONT_SIZE, space_on_x=True):
         else:
             lbl_kwargs = dict(
                 x=time_val,
-                y=p.y_range.end if hasattr(p.y_range, "end") else 10**21,
+                y=p.y_range.end if hasattr(p.y_range, "end") else 1e21,
                 text_align="center",
                 text_baseline="top",
             )

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -53,3 +53,32 @@ class TestAddMagnitudeLabels:
         p = create_space_time_figure()
         result = add_magnitude_labels(p)
         assert type(result).__name__ == "figure"
+
+
+class TestRangeBoundsJSSafe:
+    """Regression for Bokeh `out of range integer may result in loss of
+    precision` warning. Range bounds get serialized to JS `Number`, which
+    loses precision beyond 2**53 - 1. All axis-range bounds must therefore
+    be floats, not Python ints.
+    """
+
+    _MAX_SAFE_INT = 2**53 - 1  # JavaScript Number.MAX_SAFE_INTEGER
+
+    def _assert_safe(self, v):
+        # Bokeh only warns for `int`, not `float`. The fix is to use 1eN
+        # literals (floats) rather than 10**N (ints) for large bounds.
+        if isinstance(v, int) and not isinstance(v, bool):
+            assert abs(v) <= self._MAX_SAFE_INT, (
+                f"range bound {v!r} is an int > 2**53; will trigger "
+                "BokehUserWarning on serialization. Use a float literal."
+            )
+
+    def test_range_bounds_are_js_safe_space_on_x(self):
+        p = create_space_time_figure(space_on_x=True)
+        for v in (p.x_range.start, p.x_range.end, p.y_range.start, p.y_range.end):
+            self._assert_safe(v)
+
+    def test_range_bounds_are_js_safe_time_on_x(self):
+        p = create_space_time_figure(space_on_x=False)
+        for v in (p.x_range.start, p.x_range.end, p.y_range.start, p.y_range.end):
+            self._assert_safe(v)


### PR DESCRIPTION
Bokeh emits `BokehUserWarning: out of range integer may result in loss of precision` 12× when building the diagram. Root cause: `10**21` evaluates to a Python `int` (1000000000000000000000). Bokeh serializes numeric values to JS `Number`, which loses precision above `Number.MAX_SAFE_INTEGER = 2**53 - 1 ≈ 9.007e15`. The value gets serialized 12× (ticks, ranges, properties), hence 12 warnings.

Fix: change the three `10**21` literals in `plotting.py` to `1e21` (float). For consistency the sibling bounds on the same range tuples are also written in scientific notation.

- `plotting.py:98` — `(10**-27, 10**21), (10**12, 10**-3)` → `(1e-27, 1e21), (1e12, 1e-3)`
- `plotting.py:101` — `(10**-3, 10**12), (10**-21, 10**21)` → `(1e-3, 1e12), (1e-21, 1e21)`
- `plotting.py:233` — fallback `else 10**21` → `else 1e21`

Added regression test `TestRangeBoundsJSSafe` in `tests/test_plotting.py` that asserts no axis-range bound is a Python `int` exceeding `2**53 - 1` for either `space_on_x=True` or `False`.

Verified: instrumenting `bokeh.core.serialization.Serializer._encode_int` with the fix applied, the out-of-range int count drops from 12 to 0 when building the test diagram.

Other `10**N` uses in `plotting.py` (exponents -27, -3, -1) are safe (either negative → float, or under the 2^53 ceiling) and are left unchanged to keep the diff focused.