### PR TITLE
docs: clarify what can and cannot be edited in Google Form scale answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ processed = transform_process_response_sheet(df)
 5. In `constants.py`, set `PROCESSES_URI` to the identifying string between `/d/` and `/edit` in the sheet URL.
    For example: `https://docs.google.com/spreadsheets/d/USE_THIS_PART/edit?gid=0#gid=0`
 
+> **Editing the Time / Space scale answer options**
+>
+> The scale answer options in the form follow the format `<value>: <example>`, for instance `1.00E+07: ~3 months`.
+>
+> - The **numeric value before the `:`** (e.g. `1.00E+07`) is what the ETL parses and plots. Do **not** change these — the code (`etl.py`) splits on `:` and casts the prefix to `float`, so anything non-numeric or out of the expected decade will break downstream processing or silently shift your data.
+> - The **example text after the `:`** (e.g. `~3 months`) is purely a human-readable anchor. You can edit it freely to make the scale more intuitive for your respondents.
+
 ### Setting up a measurement form
 
 Follow the same steps as above, using your measurement form template, and set `MEASUREMENTS_URI` in `constants.py`.


### PR DESCRIPTION
Adds a note to the **Setting up a processes form** section of the README explaining which parts of the Time/Space scale answer options are safe to edit and which are not.

### Context

The form's scale answer options use the format `<value>: <example>`, e.g. `1.00E+07: ~3 months`. The ETL in `etl.py:30` does `row[column].split(":").pop(0)` — it keeps only the numeric prefix and ignores whatever is after the colon. This means:

- The numeric value before the `:` is load-bearing. Changing `1.00E+07` to `1.00E+7` or `10000000` will change downstream parsing/typing; removing a decade will silently shift responses.
- The text after the `:` is purely a human-readable anchor. It can be edited freely — e.g. swapping `~3 months` for `115 days` or `1 growing season` is fine.

### Change

Inline note in the README right after the form-copy instructions. No code changes.