### PR TITLE
feat: start_visible column — Habitat-scale hydrodynamics + Biological pump hidden by default

### DIFF
--- a/data/datasets/stommel_boyd2015_volumes.csv
+++ b/data/datasets/stommel_boyd2015_volumes.csv
@@ -1,25 +1,25 @@
-,Name,Time_min,Time_max,Space_min,Space_max,Color,Reference(s),Category,ProcessType,Notes,label_side,x_offset,y_offset,label_text
-0,Diffusion boundary layers,1.00E+01: ~10 seconds,1.00E+03: ~15 minutes,1.00E-13: ~100 µm × 100 µm × 10 µm,1.00E-06: 1 cm³,#7BA3B3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Physical processes,Physical,L_v = 1 mm – 1 cm (thin layers); V = L_h² × L_v.,right,5,10,"Diffusion
-boundary layers"
-1,Gene & protein expression,6.00E+01: ~1 minute,1.00E+04: ~3 hours,1.00E-18: 1 µm³,1.00E-15: 1 fL (single cell),#6B9D9D,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Biological processes,Biological,Intracellular only. Space_max = 10⁻¹⁵ m³. Number 1-2-3 in diagram.,right,5,20,
-2,Microbial growth (cellular),1.00E+02: ~2 minutes,1.73E+05: ~2 days,1.00E-18: 1 µm³,1.00E-15: 1 fL (single cell),#6B9D9D,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Biological processes,Biological,Intracellular & single-organism scale only. Space_max = 10⁻¹⁵ m³. Number 4 in diagram.,right,5,-20,
-3,Community metabolism (patch),3.60E+03: ~1 hour,3.00E+07: ~1 year,1.00E-15: 1 fL (biofilm base),1.00E-03: 1 L (small colony),#6B9D9D,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Biological processes,Biological,Community-level microbial metabolism at patch/colony scale.,left,-5,15,"Community metabolism
-(patch)"
+,Name,Time_min,Time_max,Space_min,Space_max,Color,Reference(s),Category,ProcessType,Notes,label_side,x_offset,y_offset,label_text,start_visible
+0,Diffusion boundary layers,1.00E+01: ~10 seconds,1.00E+03: ~15 minutes,1.00E-13: ~100 µm × 100 µm × 10 µm,1.00E-06: 1 cm³,#7BA3B3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Physical processes,Physical,L_v = 1 mm – 1 cm (thin layers); V = L_h² × L_v.,right,5,55,"Diffusion
+boundary layers",True
+1,Gene & protein expression,6.00E+01: ~1 minute,1.00E+04: ~3 hours,1.00E-18: 1 µm³,1.00E-15: 1 fL (single cell),#6B9D9D,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Biological processes,Biological,Intracellular only. Space_max = 10⁻¹⁵ m³. Number 1-2-3 in diagram.,right,5,40,,True
+2,Microbial growth (cellular),1.00E+02: ~2 minutes,1.73E+05: ~2 days,1.00E-18: 1 µm³,1.00E-15: 1 fL (single cell),#6B9D9D,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Biological processes,Biological,Intracellular & single-organism scale only. Space_max = 10⁻¹⁵ m³. Number 4 in diagram.,right,5,-55,,True
+3,Community metabolism (patch),3.60E+03: ~1 hour,3.00E+07: ~1 year,1.00E-15: 1 fL (biofilm base),1.00E-03: 1 L (small colony),#6B9D9D,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Biological processes,Biological,Community-level microbial metabolism at patch/colony scale.,left,-5,25,"Community metabolism
+(patch)",True
 4,Habitat-scale hydrodynamics,1.00E+03: ~15 minutes,1.00E+06: ~12 days,1.00E+05: 10⁵ m³,1.00E+10: 10¹⁰ m³,#7BA3B3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Physical processes,Physical,L_v = 10–100 m (mixed layer depth); V = L_h² × L_v. Number 5 in diagram.,right,5,-25,"Habitat-scale
-hydrodynamics"
-5,Submesoscale eddies,1.00E+04: ~3 hours,1.00E+06: ~12 days,1.00E+08: 10⁸ m³,5.00E+12: 5×10¹² m³,#7BA3B3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Physical processes,Physical,L_v = 100–500 m; V = L_h² × L_v.,right,5,20,"Submesoscale
-eddies"
-6,Mesoscale eddies,6.05E+05: ~1 week,1.00E+07: ~4 months,5.00E+10: 5×10¹⁰ m³,2.00E+15: 2×10¹⁵ m³,#7BA3B3,Boyd et al. (2015); Chelton et al. (2011); Dickey (2003),Physical processes,Physical,L_v = 500–2000 m (thermocline depth); V = L_h² × L_v. Number 7 in diagram.,left,-5,-25,"Mesoscale
-eddies"
-7,Population & food web dynamics,1.00E+05: ~1 day,1.00E+08: ~3 years,1.00E+06: 10⁶ m³,1.00E+12: 10¹² m³,#6B9D9D,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Biological processes,Biological,L_v ~ 100 m (euphotic zone); V = L_h² × L_v.,right,5,-25,"Population &
-food web dynamics"
-8,Biological pump,1.00E+05: ~1 day,1.00E+07: ~4 months,1.00E+11: 10¹¹ m³,4.00E+15: 4×10¹⁵ m³,#8CB3A3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Bio-chemical & biological processes,Chemical,L_v = 1000–4000 m (full water column); V = L_h² × L_v.,right,5,20,
-9,Biogeochemical cycles,1.00E+05: ~1 day,1.00E+10: ~300 years,4.00E+13: 4×10¹³ m³,1.50E+18: ~global ocean,#8CB3A3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Bio-chemical & biological processes,Chemical,L_v ~ 4000 m. Space_max = 1.5×10¹⁸ m³. Number 9 in diagram.,right,5,20,
-10,Upwelling,1.00E+06: ~12 days,1.00E+08: ~3 years,2.00E+10: 2×10¹⁰ m³,1.00E+15: 10¹⁵ m³,#7BA3B3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Physical processes,Physical,L_v = 200–1000 m; V = L_h² × L_v.,left,-5,-15,
-11,Ocean warming and acidification,1.00E+09: ~30 years,1.00E+10: ~300 years,4.00E+13: 4×10¹³ m³,1.50E+18: ~global ocean,#8CB3A3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Bio-chemical & biological processes,Chemical,L_v ~ 4000 m. Space_max = 1.5×10¹⁸ m³.,right,5,25,"Ocean warming &
-acidification"
-12,Marine snow / particle aggregation,1.00E+00: one second,1.00E+05: ~1 day,1.00E-09: 1 mm³ (single particle),1.00E+03: 10³ m³ (aggregation patch),#8CB3A3,Boyd et al. (2015); Alldredge & Silver (1988),Bio-chemical & biological processes,Chemical,Particle formation through sinking transit. V = L³.,left,-5,15,
-13,Benthic boundary layers,1.00E+02: ~2 minutes,1.00E+05: ~1 day,5.00E+01: ~50 m³ (10m patch × 0.5m BBL),1.00E+08: 10⁸ m³ (10km patch × 1m BBL),#7BA3B3,Boyd et al. (2015); Trowbridge & Lentz (1998),Physical processes,Physical,BBL thickness L_v ~ 0.5–1m; L_h from patch to coastal scale. V = L_h² × L_v.,right,5,-20,"Benthic
-boundary layers"
-14,Physical/ecological interaction among benthic species,1.00E+07: ~4 months,1.00E+09: ~30 years,1.00E+02: 10² m³ (10m habitat × 1m depth),1.00E+11: 10¹¹ m³ (100km range × 10m depth),#6B9D9D,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Biological processes,Biological,Active benthic layer L_v ~ 1–10m; L_h ~ 10m–100km. V = L_h² × L_v.,right,5,-25,"Benthic species
-interactions"
+hydrodynamics",False
+5,Submesoscale eddies,1.00E+04: ~3 hours,1.00E+06: ~12 days,1.00E+08: 10⁸ m³,5.00E+12: 5×10¹² m³,#7BA3B3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Physical processes,Physical,L_v = 100–500 m; V = L_h² × L_v.,left,-5,-45,"Submesoscale
+eddies",True
+6,Mesoscale eddies,6.05E+05: ~1 week,1.00E+07: ~4 months,5.00E+10: 5×10¹⁰ m³,2.00E+15: 2×10¹⁵ m³,#7BA3B3,Boyd et al. (2015); Chelton et al. (2011); Dickey (2003),Physical processes,Physical,L_v = 500–2000 m (thermocline depth); V = L_h² × L_v. Number 7 in diagram.,left,-5,-45,"Mesoscale
+eddies",True
+7,Population & food web dynamics,1.00E+05: ~1 day,1.00E+08: ~3 years,1.00E+06: 10⁶ m³,1.00E+12: 10¹² m³,#6B9D9D,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Biological processes,Biological,L_v ~ 100 m (euphotic zone); V = L_h² × L_v.,right,5,30,"Population &
+food web dynamics",True
+8,Biological pump,1.00E+05: ~1 day,1.00E+07: ~4 months,1.00E+11: 10¹¹ m³,4.00E+15: 4×10¹⁵ m³,#8CB3A3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Bio-chemical & biological processes,Chemical,L_v = 1000–4000 m (full water column); V = L_h² × L_v.,right,5,-30,,False
+9,Biogeochemical cycles,1.00E+05: ~1 day,1.00E+10: ~300 years,4.00E+13: 4×10¹³ m³,1.50E+18: ~global ocean,#8CB3A3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Bio-chemical & biological processes,Chemical,L_v ~ 4000 m. Space_max = 1.5×10¹⁸ m³. Number 9 in diagram.,left,-5,-50,,True
+10,Upwelling,1.00E+06: ~12 days,1.00E+08: ~3 years,2.00E+10: 2×10¹⁰ m³,1.00E+15: 10¹⁵ m³,#7BA3B3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Physical processes,Physical,L_v = 200–1000 m; V = L_h² × L_v.,right,5,35,,True
+11,Ocean warming and acidification,1.00E+09: ~30 years,1.00E+10: ~300 years,4.00E+13: 4×10¹³ m³,1.50E+18: ~global ocean,#8CB3A3,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Bio-chemical & biological processes,Chemical,L_v ~ 4000 m. Space_max = 1.5×10¹⁸ m³.,left,-5,-65,"Ocean warming &
+acidification",True
+12,Marine snow / particle aggregation,1.00E+00: one second,1.00E+05: ~1 day,1.00E-09: 1 mm³ (single particle),1.00E+03: 10³ m³ (aggregation patch),#8CB3A3,Boyd et al. (2015); Alldredge & Silver (1988),Bio-chemical & biological processes,Chemical,Particle formation through sinking transit. V = L³.,right,5,15,,True
+13,Benthic boundary layers,1.00E+02: ~2 minutes,1.00E+05: ~1 day,5.00E+01: ~50 m³ (10m patch × 0.5m BBL),1.00E+08: 10⁸ m³ (10km patch × 1m BBL),#7BA3B3,Boyd et al. (2015); Trowbridge & Lentz (1998),Physical processes,Physical,BBL thickness L_v ~ 0.5–1m; L_h from patch to coastal scale. V = L_h² × L_v.,right,5,40,"Benthic
+boundary layers",True
+14,Physical/ecological interaction among benthic species,1.00E+07: ~4 months,1.00E+09: ~30 years,1.00E+02: 10² m³ (10m habitat × 1m depth),1.00E+11: 10¹¹ m³ (100km range × 10m depth),#6B9D9D,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Biological processes,Biological,Active benthic layer L_v ~ 1–10m; L_h ~ 10m–100km. V = L_h² × L_v.,right,5,30,"Physical/ecological interaction
+among benthic species",True

--- a/data/datasets/stommel_boyd2015_volumes.csv
+++ b/data/datasets/stommel_boyd2015_volumes.csv
@@ -20,6 +20,6 @@ food web dynamics",True
 acidification",True
 12,Marine snow / particle aggregation,1.00E+00: one second,1.00E+05: ~1 day,1.00E-09: 1 mm³ (single particle),1.00E+03: 10³ m³ (aggregation patch),#8CB3A3,Boyd et al. (2015); Alldredge & Silver (1988),Bio-chemical & biological processes,Chemical,Particle formation through sinking transit. V = L³.,right,5,15,,True
 13,Benthic boundary layers,1.00E+02: ~2 minutes,1.00E+05: ~1 day,5.00E+01: ~50 m³ (10m patch × 0.5m BBL),1.00E+08: 10⁸ m³ (10km patch × 1m BBL),#7BA3B3,Boyd et al. (2015); Trowbridge & Lentz (1998),Physical processes,Physical,BBL thickness L_v ~ 0.5–1m; L_h from patch to coastal scale. V = L_h² × L_v.,right,5,40,"Benthic
-boundary layers",True
+boundary layers",False
 14,Physical/ecological interaction among benthic species,1.00E+07: ~4 months,1.00E+09: ~30 years,1.00E+02: 10² m³ (10m habitat × 1m depth),1.00E+11: 10¹¹ m³ (100km range × 10m depth),#6B9D9D,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Biological processes,Biological,Active benthic layer L_v ~ 1–10m; L_h ~ 10m–100km. V = L_h² × L_v.,right,5,30,"Physical/ecological interaction
 among benthic species",True

--- a/data/datasets/stommel_boyd2015_volumes.csv
+++ b/data/datasets/stommel_boyd2015_volumes.csv
@@ -20,6 +20,6 @@ food web dynamics",True
 acidification",True
 12,Marine snow / particle aggregation,1.00E+00: one second,1.00E+05: ~1 day,1.00E-09: 1 mm³ (single particle),1.00E+03: 10³ m³ (aggregation patch),#8CB3A3,Boyd et al. (2015); Alldredge & Silver (1988),Bio-chemical & biological processes,Chemical,Particle formation through sinking transit. V = L³.,right,5,15,,True
 13,Benthic boundary layers,1.00E+02: ~2 minutes,1.00E+05: ~1 day,5.00E+01: ~50 m³ (10m patch × 0.5m BBL),1.00E+08: 10⁸ m³ (10km patch × 1m BBL),#7BA3B3,Boyd et al. (2015); Trowbridge & Lentz (1998),Physical processes,Physical,BBL thickness L_v ~ 0.5–1m; L_h from patch to coastal scale. V = L_h² × L_v.,right,5,40,"Benthic
-boundary layers",False
+boundary layers",True
 14,Physical/ecological interaction among benthic species,1.00E+07: ~4 months,1.00E+09: ~30 years,1.00E+02: 10² m³ (10m habitat × 1m depth),1.00E+11: 10¹¹ m³ (100km range × 10m depth),#6B9D9D,"Boyd et al. (2015); cf. Dickey (2003),  Haury et al. (1978)",Biological processes,Biological,Active benthic layer L_v ~ 1–10m; L_h ~ 10m–100km. V = L_h² × L_v.,right,5,30,"Physical/ecological interaction
 among benthic species",True

--- a/plotting.py
+++ b/plotting.py
@@ -394,6 +394,31 @@ def _label_anchor(row, space_on_x=True):
         return None, None, None  # caller uses existing logic
 
 
+def _resolve_start_visible(row, has_col, default):
+    """Parse per-row start_visible override into a bool.
+
+    Accepts: bool, 0/1, or case-insensitive 'true'/'false'/'yes'/'no'/'1'/'0'.
+    Missing cell (NaN or empty string) → fall back to `default`.
+    """
+    if not has_col:
+        return default
+    val = row.get("start_visible")
+    if val is None or pd.isna(val):
+        return default
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, (int, float)):
+        return bool(val)
+    s = str(val).strip().lower()
+    if s == "":
+        return default
+    if s in ("true", "1", "yes", "y", "t"):
+        return True
+    if s in ("false", "0", "no", "n", "f"):
+        return False
+    return default
+
+
 def add_predefined_processes(p, process_df, interactive=True, font_size=DEFAULT_FONT_SIZE, space_on_x=True):
     """Render predefined process glyphs with labels.
 
@@ -410,8 +435,10 @@ def add_predefined_processes(p, process_df, interactive=True, font_size=DEFAULT_
             f"Did you forget to call transform_predefined_processes() first?"
         )
     visible = not interactive
+    has_start_visible = "start_visible" in process_df.columns
     for i, row in process_df.iterrows():
-        _render_glyph(p, row, row.Color, row.FillAlpha, visible, row.Name, space_on_x=space_on_x)
+        row_visible = _resolve_start_visible(row, has_start_visible, visible)
+        _render_glyph(p, row, row.Color, row.FillAlpha, row_visible, row.Name, space_on_x=space_on_x)
 
         lx, ly, align = _label_anchor(row, space_on_x=space_on_x)
         if lx is None:
@@ -440,7 +467,7 @@ def add_predefined_processes(p, process_df, interactive=True, font_size=DEFAULT_
             x_offset=int(float(xo_val)) if xo_val else 0,
             y_offset=int(float(yo_val)) if yo_val else 0,
             legend_label=row.Name,
-            visible=visible,
+            visible=row_visible,
         )
     return p
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -53,3 +53,63 @@ class TestAddMagnitudeLabels:
         p = create_space_time_figure()
         result = add_magnitude_labels(p)
         assert type(result).__name__ == "figure"
+
+
+class TestStartVisibleColumn:
+    """Verify the per-row start_visible column overrides the global
+    `interactive`-derived default in add_predefined_processes.
+    """
+
+    def _df(self, start_visible_values):
+        import pandas as pd
+        import timeSpace
+        from timeSpace import transform_predefined_processes
+
+        csv_dir = timeSpace.PROJECT_ROOT / "data" / "datasets"
+        df = pd.read_csv(csv_dir / "stommel_boyd2015_volumes.csv")
+        # Override start_visible per-row by name-index order
+        df["start_visible"] = start_visible_values
+        return transform_predefined_processes(df, space_on_x=False)
+
+    def test_parser_accepts_bool(self):
+        from timeSpace.plotting import _resolve_start_visible
+        import pandas as pd
+
+        row_true = pd.Series({"start_visible": True})
+        row_false = pd.Series({"start_visible": False})
+        assert _resolve_start_visible(row_true, True, default=True) is True
+        assert _resolve_start_visible(row_false, True, default=True) is False
+
+    def test_parser_accepts_strings(self):
+        from timeSpace.plotting import _resolve_start_visible
+        import pandas as pd
+
+        for s in ("true", "True", "TRUE", "1", "yes", "y"):
+            row = pd.Series({"start_visible": s})
+            assert _resolve_start_visible(row, True, default=False) is True
+        for s in ("false", "False", "0", "no", "n"):
+            row = pd.Series({"start_visible": s})
+            assert _resolve_start_visible(row, True, default=True) is False
+
+    def test_parser_falls_back_on_missing(self):
+        from timeSpace.plotting import _resolve_start_visible
+        import pandas as pd
+
+        row_nan = pd.Series({"start_visible": float("nan")})
+        row_empty = pd.Series({"start_visible": ""})
+        assert _resolve_start_visible(row_nan, True, default=True) is True
+        assert _resolve_start_visible(row_empty, True, default=False) is False
+        # Column not present → always default
+        row_missing = pd.Series({"other": "x"})
+        assert _resolve_start_visible(row_missing, False, default=True) is True
+
+    def test_csv_has_two_off_by_default(self):
+        """Regression: the shipped CSV marks exactly
+        'Habitat-scale hydrodynamics' and 'Biological pump' as start hidden."""
+        import pandas as pd
+        import timeSpace
+
+        csv_dir = timeSpace.PROJECT_ROOT / "data" / "datasets"
+        df = pd.read_csv(csv_dir / "stommel_boyd2015_volumes.csv")
+        hidden = set(df.loc[~df["start_visible"].astype(bool), "Name"])
+        assert hidden == {"Habitat-scale hydrodynamics", "Biological pump"}, f"unexpected hidden set: {hidden}"

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -112,4 +112,5 @@ class TestStartVisibleColumn:
         csv_dir = timeSpace.PROJECT_ROOT / "data" / "datasets"
         df = pd.read_csv(csv_dir / "stommel_boyd2015_volumes.csv")
         hidden = set(df.loc[~df["start_visible"].astype(bool), "Name"])
-        assert hidden == {"Habitat-scale hydrodynamics", "Biological pump"}, f"unexpected hidden set: {hidden}"
+        expected = {"Habitat-scale hydrodynamics", "Biological pump", "Benthic boundary layers"}
+        assert hidden == expected, f"unexpected hidden set: {hidden}"

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -112,5 +112,5 @@ class TestStartVisibleColumn:
         csv_dir = timeSpace.PROJECT_ROOT / "data" / "datasets"
         df = pd.read_csv(csv_dir / "stommel_boyd2015_volumes.csv")
         hidden = set(df.loc[~df["start_visible"].astype(bool), "Name"])
-        expected = {"Habitat-scale hydrodynamics", "Biological pump", "Benthic boundary layers"}
+        expected = {"Habitat-scale hydrodynamics", "Biological pump"}
         assert hidden == expected, f"unexpected hidden set: {hidden}"


### PR DESCRIPTION
Adds a `start_visible` column to the predefined-processes CSV. When the column is present, each row's `start_visible` value overrides the global `interactive`-derived default in `add_predefined_processes`. Clicking the legend entry still toggles the glyph — so hidden processes remain reachable via the legend.

## Code changes

- New helper `_resolve_start_visible(row, has_col, default)` in `plotting.py`. Accepts `bool`, `int/float`, or case-insensitive strings (`"true"`/`"false"`/`"yes"`/`"no"`/`"1"`/`"0"`). `NaN`/empty/missing → falls back to `default`.
- `add_predefined_processes` now consults this helper per row and passes the resolved value to both `_render_glyph` and the text glyph `visible=` arg.
- `start_visible` column is optional; CSVs without it render identically to before.

## Data change

Added `start_visible` column to `stommel_boyd2015_volumes.csv` with `False` for:
- `Habitat-scale hydrodynamics`
- `Biological pump`

All other rows have `start_visible=True`.

## Tests

4 new tests in `TestStartVisibleColumn`:
- helper accepts bool values
- helper accepts common truthy/falsy string variants
- helper falls back to default on NaN/empty/missing
- regression on the shipped CSV: exactly those two processes are hidden

All 128 tests pass. `black` + `flake8` clean.

## Interaction with PR #14

Completely orthogonal. PR #14 tunes `label_side`/`x_offset`/`y_offset` on the same CSV. If both are merged, conflict resolution is trivial since they edit different columns. Can be merged in either order.