### PR TITLE
chore(tests): move per-function imports to module level

### DIFF
--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -1,14 +1,16 @@
 import numpy as np
+import pandas as pd
 import astropy.units as u
 import pytest
 
 from timeSpace.calculations import (
-    create_ellipse_data,
-    calculate_sphere_volume,
     calculate_diffusion_length,
+    calculate_log10_y_for_ellipse,
     calculate_log_center,
     calculate_log_width,
+    calculate_sphere_volume,
     classify_process_geometry,
+    create_ellipse_data,
 )
 
 
@@ -61,8 +63,6 @@ class TestLogHelpers:
 class TestCreateEllipseData:
     @pytest.fixture
     def sample_row(self):
-        import pandas as pd
-
         return pd.Series(
             {
                 "Time_min": 1e2 * u.second,
@@ -128,8 +128,6 @@ class TestCreateEllipseData:
 
     def test_degenerate_time_raises(self):
         """Degenerate time axis should raise ValueError."""
-        import pandas as pd
-
         row = pd.Series(
             {
                 "Time_min": 1e3 * u.second,
@@ -143,8 +141,6 @@ class TestCreateEllipseData:
 
     def test_degenerate_space_raises(self):
         """Degenerate space axis should raise ValueError."""
-        import pandas as pd
-
         row = pd.Series(
             {
                 "Time_min": 1e2 * u.second,
@@ -161,8 +157,6 @@ class TestCalculateLog10YForEllipse:
     """Tests for the log10-space ellipse Y solver."""
 
     def test_at_center_returns_extremes(self):
-        from timeSpace.calculations import calculate_log10_y_for_ellipse
-
         # At x = 10^c_x, inner term is zero → y = c_y ± b
         c_x, c_y, a, b = 3.0, 5.0, 2.0, 1.5
         x = 10**c_x
@@ -171,8 +165,6 @@ class TestCalculateLog10YForEllipse:
         np.testing.assert_allclose(minus, c_y - b, rtol=1e-10)
 
     def test_at_edge_returns_center(self):
-        from timeSpace.calculations import calculate_log10_y_for_ellipse
-
         # At x = 10^(c_x + a) (right edge), y should collapse to c_y
         c_x, c_y, a, b = 3.0, 5.0, 2.0, 1.5
         x = 10 ** (c_x + a)
@@ -181,8 +173,6 @@ class TestCalculateLog10YForEllipse:
         np.testing.assert_allclose(minus, c_y, atol=1e-6)
 
     def test_symmetric_about_center(self):
-        from timeSpace.calculations import calculate_log10_y_for_ellipse
-
         c_x, c_y, a, b = 3.0, 5.0, 2.0, 1.5
         # Points equidistant from center in log-x should give same y spread
         x_left = 10 ** (c_x - 1.0)
@@ -197,8 +187,6 @@ class TestClassifyProcessGeometry:
 
     @staticmethod
     def _make_row(t_min, t_max, s_min, s_max):
-        import pandas as pd
-
         return pd.Series(
             {
                 "Time_min": t_min * u.second,

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -2,11 +2,11 @@
 
 from bokeh.models import GlyphRenderer, Label
 
+from timeSpace import demo
+
 
 def test_demo_returns_figure():
     """demo(show=False) returns a Bokeh figure without opening a browser."""
-    from timeSpace import demo
-
     p = demo(show=False)
     assert p is not None
     assert hasattr(p, "renderers")
@@ -14,8 +14,6 @@ def test_demo_returns_figure():
 
 def test_demo_has_processes():
     """demo figure should contain process ellipse renderers."""
-    from timeSpace import demo
-
     p = demo(show=False)
     glyph_renderers = [r for r in p.renderers if isinstance(r, GlyphRenderer)]
     # At minimum: diffusion lines, light cone, process patches/glyphs
@@ -24,8 +22,6 @@ def test_demo_has_processes():
 
 def test_demo_has_labels():
     """demo figure should have Label annotations (magnitude labels)."""
-    from timeSpace import demo
-
     p = demo(show=False)
     labels = [obj for obj in p.center if isinstance(obj, Label)]
     assert len(labels) >= 1
@@ -33,7 +29,5 @@ def test_demo_has_labels():
 
 def test_demo_has_legend():
     """demo figure should include a legend."""
-    from timeSpace import demo
-
     p = demo(show=False)
     assert len(p.legend) >= 1

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import astropy.units as u
-
-from timeSpace.etl import process_magnitude_column
+from timeSpace.etl import process_magnitude_column, transform_predefined_processes
 from timeSpace.constants import base_time, base_space
 
 
@@ -34,7 +33,6 @@ class TestProcessMagnitudeColumn:
 
 class TestTransformPredefinedProcesses:
     def test_produces_expected_columns(self):
-        from timeSpace.etl import transform_predefined_processes
 
         df = pd.DataFrame(
             {
@@ -52,7 +50,6 @@ class TestTransformPredefinedProcesses:
             assert col in result.columns, f"Missing column: {col}"
 
     def test_units_applied(self):
-        from timeSpace.etl import transform_predefined_processes
 
         df = pd.DataFrame(
             {
@@ -71,7 +68,6 @@ class TestTransformPredefinedProcesses:
         assert row.Space_max.unit == u.m**3
 
     def test_ellipse_data_generated(self):
-        from timeSpace.etl import transform_predefined_processes
 
         df = pd.DataFrame(
             {

--- a/tests/test_local_install.py
+++ b/tests/test_local_install.py
@@ -5,6 +5,11 @@ Run after installing from sdist/wheel (not editable mode):
     make test-package
 
 Generates test_stommel.html — an embeddable Stommel diagram.
+
+NOTE: Imports inside `main()` are intentional — verifying that the public
+API is importable post-install (and capturing SyntaxWarnings during
+`from timeSpace import constants`) is what this test does. Do not move
+them to module level.
 """
 
 import sys

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,6 +1,6 @@
 from bokeh.models import LogAxis
 
-from timeSpace.plotting import create_space_time_figure
+from timeSpace.plotting import add_magnitude_labels, create_space_time_figure
 
 
 class TestCreateSpaceTimeFigure:
@@ -38,8 +38,6 @@ class TestCreateSpaceTimeFigure:
 
 class TestAddMagnitudeLabels:
     def test_adds_layout_elements(self):
-        from timeSpace.plotting import add_magnitude_labels, create_space_time_figure
-
         p = create_space_time_figure()
         before = len(p.center)
         add_magnitude_labels(p)
@@ -48,8 +46,6 @@ class TestAddMagnitudeLabels:
         assert after > before
 
     def test_returns_figure(self):
-        from timeSpace.plotting import add_magnitude_labels, create_space_time_figure
-
         p = create_space_time_figure()
         result = add_magnitude_labels(p)
         assert type(result).__name__ == "figure"


### PR DESCRIPTION
Sweeps the test files for unnecessary in-function imports and consolidates them at module top.

## Why

Several test files had `import X` lines inside test methods with no technical justification — no circular imports, no expensive deferred loads, no conditional imports, no `try/except ImportError` wrappers. Just legacy copy-paste. This PR moves them to module level for consistency.

## Files touched

| File | Imports moved |
|---|---|
| `tests/test_calculations.py` | `pandas`, `calculate_log10_y_for_ellipse` |
| `tests/test_demo.py` | `from timeSpace import demo` |
| `tests/test_etl.py` | `transform_predefined_processes` |
| `tests/test_plotting.py` | `add_magnitude_labels` |

## Files deliberately left alone

`tests/test_local_install.py` — its in-function imports inside `main()` are load-bearing for what the test actually verifies:
- `from timeSpace import (...)` is wrapped in `try/except ImportError` to verify the public API is importable post-install (would crash the script at module-load time if moved to top).
- `from timeSpace import constants` is inside a `with warnings.catch_warnings(record=True)` block to capture any `SyntaxWarning` raised during that import.

Added a docstring note to make this intent explicit for future readers.

## Verification

124 tests pass. `black` + `flake8` clean. No behavior changes — pure refactor.

## Note on PR #18

PR #18 (Stommel label overhaul) adds two new test classes — those already use module-level imports as of the most recent force-push. This PR just cleans up the *pre-existing* test files. After merging both, the entire `tests/` directory will be consistent (except `test_local_install.py`, intentionally).