### PR TITLE
fix(desert-farm): build pipeline papercuts (etl warning + script-relative defaults)

### DIFF
--- a/docs/build_desert_farm.py
+++ b/docs/build_desert_farm.py
@@ -357,7 +357,9 @@ def build_desert_farm_figure(csv_path, output_path):
 
 if __name__ == "__main__":
     import sys
+    from pathlib import Path
 
-    csv_path = sys.argv[1] if len(sys.argv) > 1 else "desert_farm_processes.csv"
-    output_path = sys.argv[2] if len(sys.argv) > 2 else "desert_farm_stommel.html"
+    HERE = Path(__file__).resolve().parent
+    csv_path = sys.argv[1] if len(sys.argv) > 1 else HERE / "desert_farm_processes.csv"
+    output_path = sys.argv[2] if len(sys.argv) > 2 else HERE / "desert_farm_stommel.html"
     build_desert_farm_figure(csv_path, output_path)

--- a/docs/build_desert_farm_summary.py
+++ b/docs/build_desert_farm_summary.py
@@ -77,7 +77,7 @@ def add_cascade_arrows(p, process_df):
 
 def build_summary_figure(csv_path=None, output_path=None):
     csv_path = csv_path or DEFAULT_CSV
-    output_path = output_path or "desert_farm_summary.html"
+    output_path = output_path or Path(__file__).resolve().parent / "desert_farm_summary.html"
 
     process_df = load_and_transform(csv_path)
 

--- a/etl.py
+++ b/etl.py
@@ -65,7 +65,7 @@ def transform_process_response_sheet(responses_df, possible_col_list=POSSIBLE_CO
         )
 
     columns_list = list(set(possible_col_list) & set(responses_df.columns))
-    plottable_responses_df = responses_df[columns_list]
+    plottable_responses_df = responses_df[columns_list].copy()
 
     for column in ["Time_min", "Time_max", "Space_min", "Space_max"]:
         plottable_responses_df[column] = plottable_responses_df.apply(process_magnitude_column, column=column, axis=1)


### PR DESCRIPTION
## Summary
Three small build-infrastructure fixes raised in the leverage-points review brief.

### Changes

**`etl.py:68`** — `plottable_responses_df = responses_df[columns_list]` was a view, so subsequent column assignments fired `SettingWithCopyWarning` on every build. Adding `.copy()` makes it a fresh DataFrame.

**`docs/build_desert_farm_summary.py`** — `output_path` default was the relative string `"desert_farm_summary.html"`, so running from repo root stranded the file at the root instead of in `docs/`. Now defaults to `Path(__file__).resolve().parent / "desert_farm_summary.html"`.

**`docs/build_desert_farm.py`** — same fix for `csv_path` and `output_path` defaults. The script can now be run from any working directory.

## Verification
Built both scripts from `/tmp` (a directory unrelated to the repo) — files land in `docs/...`, not in `/tmp/`. With `warnings.filterwarnings('error', category=pd.errors.SettingWithCopyWarning)`, `build_summary_figure()` now runs to completion without raising.

## Note on merge order
Independent of PR #20 (axes + cascade arrows + Colab link). The two PRs touch different lines in the same files — should merge cleanly in either order, but if both rebuild HTMLs after merge, only PR #20's rebuilds capture the visual changes.