### PR TITLE
Resolve R1-R8 data concerns for desert_farm_leverage_points.csv

### DIFF
--- a/data/datasets/desert_farm_leverage_points.csv
+++ b/data/datasets/desert_farm_leverage_points.csv
@@ -1,13 +1,13 @@
 Prefix,ShortName,Time_min,Time_max,Space_min,Space_max,Color,Reference
-model,Molecular Dynamics Models,1.00E-15,1.00E-09,1.00E-30,1.00E-27,#013333,
-process,CO2 fixation,7.69E-03,2.38E-01,5.79E-26,1.19E-24,#006666,Bar-On et al. (2019) PNAS 116:4738 — kcat dependent on HCO3- pool via carbonic anhydrase (Igamberdiev 2015)
-process,Nutrient transport,1.00E-02,1.00E+00,1.00E-22,1.00E-20,#006666,Moore et al. (2013) Nature Geosci 6:701
-process,Biochemical synthesis,1.00E+00,1.00E+01,1.00E-21,1.00E-19,#006666,Moore et al. (2013) Nature Geosci 6:701
-process,Growth,1.00E+05,1.00E+06,1.00E-20,1.00E-10,#006666,Moore et al. (2013) Nature Geosci 6:701
-model,Community Metabolic Models,99,1.00E+07,1.00E-18,1.00E-03,#013333,
+model,Molecular Dynamics Models,1.00E-15,1.00E-09,1.00E-30,1.00E-22,#013333,Karplus & McCammon (2002) Nat Struct Biol 9:646
+process,CO2 fixation,6.67E-02,2.38E-01,5.79E-26,1.19E-24,#006666,Bar-On et al. (2019) PNAS 116:4738 — kcat = 3-15/s natural RuBisCO; space = 0.1×–1.7× RuBisCO L8S8 enzyme volume (~7e-25 m³)
+process,Nutrient transport,1.00E-02,1.00E+00,1.00E-22,1.00E-20,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
+process,Biochemical synthesis,1.00E+00,1.00E+01,1.00E-21,1.00E-19,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
+process,Cell growth,1.00E+03,1.00E+05,1.00E-18,1.00E-14,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
+model,Community Metabolic Models,1.00E+02,1.00E+07,1.00E-18,1.00E-03,#013333,Zakem et al. (2020) ISME J 14:288
 leverage point,Community Ecology,1.00E+06,1.00E+08,1.00E-09,1.00E+00,#FF9900,Moore et al. (2013) Nature Geosci 6:701
 leverage point,Flocculation,1.00E+03,86400,1.00E-15,1.00E-09,#FF9900,Salim et al. (2011) J Appl Phycol; Vandamme et al. (2013) Biotechnol Adv 31:1680
 leverage point,Ponds,86400,3.15E+07,2000,2.00E+04,#FF9900,Design basis: 10x100x3m deep ponds (3000 m3); depth for photoinhibition protection and floc settling
-model,Biogeochemical Circulation Models,1.00E+05,1.00E+10,1.00E+09,1.00E+16,#013333,
+model,Biogeochemical Circulation Models,1.00E+05,1.00E+10,1.00E+09,1.00E+16,#013333,Levine et al. (2025) Annu Rev Earth Planet Sci 53:595
 leverage point,Sequestration,3.15E+08,1.00E+11,3.12E+09,2.91E+10,#FF9900,40 GtCO2/yr: Space_min=C as diamond (3.5 t/m3) Space_max=biomass+salt+sand (rho~1.5 t/m3) per year
-process,Extraction,3.16E+14,6.31E+15,2.03E+12,2.05E+14,#006666,Carboniferous coal (~300 Mya) + Mesozoic petroleum (~252-66 Mya); Tissot & Welte (1984)
+process,Fossil-fuel formation,3.16E+13,3.16E+15,2.03E+12,2.05E+14,#006666,Kerogen→petroleum maturation (~1-10 My) + coalification (~10-100 My); Tissot & Welte (1984)

--- a/data/references/README.md
+++ b/data/references/README.md
@@ -1,0 +1,74 @@
+# References
+
+## BioNumbers subset — `bionumbers_subset.csv`
+
+This file contains a curated subset of entries from the
+[BioNumbers database](https://bionumbers.hms.harvard.edu/) (Milo & Phillips,
+*Cell Biology by the Numbers*) that justify the time and space bounds for
+specific rows in `data/datasets/desert_farm_leverage_points.csv`.
+
+### Why a subset
+
+The full BioNumbers database contains ~14,300 entries (~27 MB as HTML export).
+Most are irrelevant to the desert farm Stommel diagram. Including only the
+cited subset keeps this repo lean and provides explicit per-number provenance.
+Each entry links back to its canonical BioNumbers page via the `URL` column.
+
+### Schema
+
+| Column | Description |
+|---|---|
+| `bion_id` | BioNumbers entry ID (stable identifier) |
+| `Properties` | Description of the measured quantity |
+| `Organism` | Organism the measurement is from |
+| `Value` | Reported value |
+| `Range` | Reported range (often empty) |
+| `Units` | Units of `Value` |
+| `URL` | Direct link to the BioNumbers entry |
+| `Cited_in_row` | Which `desert_farm_leverage_points.csv` row uses this entry |
+
+### Curation criteria
+
+- **Cell growth**: phototroph generation/doubling times (cyanobacteria, green
+  algae, diatoms). Excluded: heterotrophic bacteria, fungi, mammalian cells.
+- **Biochemical synthesis**: translation and transcription elongation rates
+  across model organisms. Used to bound time per peptide/RNA elongation.
+- **Nutrient transport**: diffusion coefficients of small molecules (CO2,
+  glucose, nitrate, ammonium) in water and intracellular environments, plus
+  representative uptake rates.
+
+### Known gaps and caveats
+
+- Several BioNumbers entries with relevant `Properties` strings have
+  `NaN` in the `Value` column (record exists but no scalar). Those were
+  excluded from this subset.
+- Phototroph-specific data is sparse for some categories (e.g., transporter
+  kinetics). Where a phototroph entry was unavailable, generic or
+  representative organism data (E. coli, Xenopus, generic) was used as a
+  proxy. This is documented per-entry in `Organism`.
+- **Cell growth Time_min mismatch**: the row's `Time_min = 1.00E+03` s
+  (~17 min) is faster than any documented phototroph cell division in this
+  subset. The fastest entry is Synechocystis PCC 6803 at 5.13 h (~1.85e4 s)
+  — about 18× slower than the lower bound. Either the row should be
+  tightened to ~1e4 s, or it should be re-scoped to include
+  cell-growth-adjacent sub-processes (ribosome biogenesis, replication
+  initiation) which can occur on shorter timescales than full division.
+
+### Updating
+
+When new rows are added to `desert_farm_leverage_points.csv` that cite
+Milo & Phillips, append matching BioNumbers entries to this subset and
+add a corresponding `Cited_in_row` value. Avoid duplication — a single
+entry can be `Cited_in_row` for multiple rows by listing them
+semicolon-separated.
+
+### Attribution
+
+BioNumbers is a project of the Milo Lab (Weizmann Institute) and the Harvard
+Medical School. Cite as: Milo R, Jorgensen P, Moran U, Weber G, Springer M
+(2010). *BioNumbers — the database of key numbers in molecular and cell
+biology*. Nucleic Acids Res. 38:D750–D753.
+DOI: [10.1093/nar/gkp889](https://doi.org/10.1093/nar/gkp889).
+
+For the broader synthesis: Milo R, Phillips R (2015). *Cell Biology by the
+Numbers*. Garland Science.

--- a/data/references/bionumbers_subset.csv
+++ b/data/references/bionumbers_subset.csv
@@ -1,0 +1,26 @@
+bion_id,Properties,Organism,Value,Range,Units,URL,Cited_in_row
+100289,Generation time,Cyanobacteria Synechocystis PCC 6803,6.0,,Hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100289,Cell growth
+102211,Mean generation time (on acetate),Green algae chlorella,20.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102211,Cell growth
+102212,mean generation time (photoautotrophic growth),Green algae chlorella,11.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102212,Cell growth
+104195,Generation time,Diatom Phaeodactylum tricornutum,15.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104195,Cell growth
+104196,Generation time,Green algae Dunaliella tertiolecta,15.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104196,Cell growth
+105638,Generation time at 30°C,Green algae Dunaliella salina,20.0,,Hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=105638,Cell growth
+111252,Doubling time,Cyanobacteria Synechocystis PCC 6803,12.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=111252,Cell growth
+111335,Fastest generation time,Cyanobacteria Synechocystis PCC 6803,5.13,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=111335,Cell growth
+100233,Translation rate of beta-galactosidase in E. coli,Bacteria Escherichia coli,14.5,'13-16,aa/s,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100233,Biochemical synthesis
+105067,Translation rate for short peptides,Bacteria Escherichia coli,22.0,'Table link - http://bionumbers.hms.harvard.edu/files/Maximal%20translation%20rate.pdf,1/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=105067,Biochemical synthesis
+104300,Translation rate on culture of nitrogen bases and glucose,Budding yeast Saccharomyces cerevisiae,9.3,,aa/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104300,Biochemical synthesis
+104598,Translation rate,Human Homo sapiens,5.0,,aa/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104598,Biochemical synthesis
+100060,RNA polymerase transcription rate of stable RNA,Bacteria Escherichia coli,85.0,'Table link - http://bionumbers.hms.harvard.edu/files/Parameters%20pertaining%20to%20the%20macromolecular%20synthesis%20rates%20in%20exponentially%20growing%20E.%20coli%20Br%20as%20a%20function%20of%20growth%20rate%20at%2037%20degrees%20celsius.pdf,nt/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100060,Biochemical synthesis
+101904,Transcription elongation rate of rRNA operons,Bacteria Escherichia coli,42.0,'±2,nucleotides/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=101904,Biochemical synthesis
+100664,Single molecule RNA polymerase II transcription rates,Bacteria Escherichia coli,12.8,'±4.9,nucleotides/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100664,Biochemical synthesis
+100662,Maximum RNA polymerase II transcription elongation rate,Mammalian tissue culture cell,71.6,,nucleotides/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100662,Biochemical synthesis
+104089,Diffusion coefficient of glucose in water,Generic,600.0,'Table link - http://bionumbers.hms.harvard.edu/files/Diffusion%20coefficients%20of%20various%20substances%20in%20Water.pdf,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104089,Nutrient transport
+104437,Diffusion coefficient of ammonium in water,Generic,1860.0,'Table link - http://bionumbers.hms.harvard.edu/files/Biofilm%20model%20parameters.pdf,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104437,Nutrient transport
+104439,Diffusion coefficient of nitrate in water,Generic,1700.0,'Table link - http://bionumbers.hms.harvard.edu/files/Biofilm%20model%20parameters.pdf,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104439,Nutrient transport
+109504,Diffusion coefficient glucose in water at 25°C,Generic,673.0,,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=109504,Nutrient transport
+110618,Diffusion coefficient of CO2 in red blood cell,Human Homo sapiens,650.0,,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=110618,Nutrient transport
+117305,Diffusion coefficient of CO2 in air,air,1.4e-05,,m2/s,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=117305,Nutrient transport
+102428,Intracellular diffusion coefficient for glucose transporter,African clawed frog Xenopus laevis,100.0,,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102428,Nutrient transport
+109673,Highest glucose uptake rate that still allows the maximal NADH formation rate,Bacteria Escherichia coli,2.4,,mmol/(gCDW·h),https://bionumbers.hms.harvard.edu/bionumber.aspx?id=109673,Nutrient transport
+109686,Glucose uptake rate of strain C-3000 in minimal M9 media,Bacteria Escherichia coli,12.0,'±0.5,mmol/gDW/h,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=109686,Nutrient transport


### PR DESCRIPTION
Resolves R1–R8 data concerns from desert_farm_dataset_issues working list.

## Changes

| ID | Row | Change |
|---|---|---|
| R1 | CO2 fixation | `Time_min` 7.69e-3 → 6.67e-2 (Bar-On natural RuBisCO kcat ceiling, 15/s) |
| R2 | Nutrient transport, Biochemical synthesis, Cell growth | Replace Moore et al. (2013) mis-citation with Milo & Phillips (2015) *Cell Biology by the Numbers* |
| R3 | Growth → **Cell growth** | Tighten bounds to single algal cell scope: Time 1e3–1e5 s, Space 1e-18 to 1e-14 m³. Population/community scales remain covered by `Community Ecology` row |
| R4 | Molecular Dynamics Models | `Space_max` 1e-27 → 1e-22 m³ (modern atomistic MD reaches 100-nm boxes) |
| R5 | Community Metabolic Models | `Time_min` `99` → `1.00E+02` (formatting consistency) |
| R6 | MD / Community Metabolic / BGC Circulation Models | Fill empty References (see below) |
| R7 | Extraction → **Fossil-fuel formation** | Time bounds reflect formation duration (kerogen maturation + coalification, ~1–100 My) rather than deposit age |
| R8 | CO2 fixation | Extend Reference text to justify both time (Bar-On kcat) and space (RuBisCO L8S8 volume) bounds |

## New references

- **Karplus & McCammon (2002)** *Nat Struct Biol* 9:646 — foundational MD review
- **Zakem et al. (2020)** *ISME J* 14:288 — community-scale microbial metabolic model
- **Levine et al. (2025)** *Annu Rev Earth Planet Sci* 53:595 — bridges genome-scale → BGC scales
- **Milo & Phillips (2015)** *Cell Biology by the Numbers* — single-cell physical/chemical rates

## Rename impact check

Searched repo for `Growth` and `Extraction` string usage. No external code/docs reference these specific row labels in the desert farm context (other CSVs use them in unrelated rows like `Grass blade growth`, `Coral reef growth`, `Oil reservoir extraction` — all distinct).

## Risks / open items

- Population growth split (Option B from working doc) was dropped — overlap with `Community Ecology` row was too large to justify
- BioNumbers spreadsheet itself is not yet in the repo; @MDunitz to add to `data/references/` and link from Reference cells when ready
- Igamberdiev (2015) carbonic-anhydrase reference dropped from CO2 fixation cell since the new `Time_min` reflects intrinsic RuBisCO kcat rather than CA-enhanced apparent rate; revert if you want to keep the mechanistic note
