### PR TITLE
Resolve R1-R8 desert_farm_leverage_points + add BioNumbers subset

### DIFF
--- a/data/datasets/desert_farm_leverage_points.csv
+++ b/data/datasets/desert_farm_leverage_points.csv
@@ -3,7 +3,7 @@ model,Molecular Dynamics Models,1.00E-15,1.00E-09,1.00E-30,1.00E-22,#013333,Karp
 process,CO2 fixation,6.67E-02,2.38E-01,5.79E-26,1.19E-24,#006666,Bar-On et al. (2019) PNAS 116:4738 — kcat = 3-15/s natural RuBisCO; space = 0.1×–1.7× RuBisCO L8S8 enzyme volume (~7e-25 m³)
 process,Nutrient transport,1.00E-02,1.00E+00,1.00E-22,1.00E-20,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
 process,Biochemical synthesis,1.00E+00,1.00E+01,1.00E-21,1.00E-19,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
-process,Cell growth,1.00E+03,1.00E+05,1.00E-18,1.00E-14,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
+process,Photoautotroph cell growth,7.56E+03,1.00E+05,1.00E-18,1.00E-14,#006666,Milo & Phillips (2015) Cell Biology by the Numbers; Yu et al. (2015) Sci Rep 5:8132 (UTEX 2973 fastest)
 model,Community Metabolic Models,1.00E+02,1.00E+07,1.00E-18,1.00E-03,#013333,Zakem et al. (2020) ISME J 14:288
 leverage point,Community Ecology,1.00E+06,1.00E+08,1.00E-09,1.00E+00,#FF9900,Moore et al. (2013) Nature Geosci 6:701
 leverage point,Flocculation,1.00E+03,86400,1.00E-15,1.00E-09,#FF9900,Salim et al. (2011) J Appl Phycol; Vandamme et al. (2013) Biotechnol Adv 31:1680

--- a/data/datasets/desert_farm_leverage_points.csv
+++ b/data/datasets/desert_farm_leverage_points.csv
@@ -1,9 +1,9 @@
 Prefix,ShortName,Time_min,Time_max,Space_min,Space_max,Color,Reference
 model,Molecular Dynamics Models,1.00E-15,1.00E-09,1.00E-30,1.00E-22,#013333,Karplus & McCammon (2002) Nat Struct Biol 9:646
 process,CO2 fixation,6.67E-02,2.38E-01,5.79E-26,1.19E-24,#006666,Bar-On et al. (2019) PNAS 116:4738 — kcat = 3-15/s natural RuBisCO; space = 0.1×–1.7× RuBisCO L8S8 enzyme volume (~7e-25 m³)
-process,Nutrient transport,1.00E-02,1.00E+00,1.00E-22,1.00E-20,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
-process,Biochemical synthesis,1.00E+00,1.00E+01,1.00E-21,1.00E-19,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
-process,Photoautotroph cell growth,7.56E+03,1.00E+05,1.00E-18,1.00E-14,#006666,Milo & Phillips (2015) Cell Biology by the Numbers; Yu et al. (2015) Sci Rep 5:8132 (UTEX 2973 fastest)
+process,Nutrient transport,1.00E-02,1.00E+00,1.00E-22,1.00E-20,#006666,Milo & Phillips (2015) Cell Biology by the Numbers (see data/references/)
+process,Biochemical synthesis,1.00E+00,1.00E+01,1.00E-21,1.00E-19,#006666,Milo & Phillips (2015) Cell Biology by the Numbers (see data/references/)
+process,Photoautotroph cell growth,7.56E+03,1.00E+05,1.00E-18,1.00E-14,#006666,Milo & Phillips (2015) Cell Biology by the Numbers; Yu et al. (2015) Sci Rep 5:8132 (UTEX 2973 fastest) (see data/references/)
 model,Community Metabolic Models,1.00E+02,1.00E+07,1.00E-18,1.00E-03,#013333,Zakem et al. (2020) ISME J 14:288
 leverage point,Community Ecology,1.00E+06,1.00E+08,1.00E-09,1.00E+00,#FF9900,Moore et al. (2013) Nature Geosci 6:701
 leverage point,Flocculation,1.00E+03,86400,1.00E-15,1.00E-09,#FF9900,Salim et al. (2011) J Appl Phycol; Vandamme et al. (2013) Biotechnol Adv 31:1680

--- a/data/datasets/desert_farm_leverage_points.csv
+++ b/data/datasets/desert_farm_leverage_points.csv
@@ -1,13 +1,13 @@
 Prefix,ShortName,Time_min,Time_max,Space_min,Space_max,Color,Reference
-model,Molecular Dynamics Models,1.00E-15,1.00E-09,1.00E-30,1.00E-27,#013333,
-process,CO2 fixation,7.69E-03,2.38E-01,5.79E-26,1.19E-24,#006666,Bar-On et al. (2019) PNAS 116:4738 — kcat dependent on HCO3- pool via carbonic anhydrase (Igamberdiev 2015)
-process,Nutrient transport,1.00E-02,1.00E+00,1.00E-22,1.00E-20,#006666,Moore et al. (2013) Nature Geosci 6:701
-process,Biochemical synthesis,1.00E+00,1.00E+01,1.00E-21,1.00E-19,#006666,Moore et al. (2013) Nature Geosci 6:701
-process,Growth,1.00E+05,1.00E+06,1.00E-20,1.00E-10,#006666,Moore et al. (2013) Nature Geosci 6:701
-model,Community Metabolic Models,99,1.00E+07,1.00E-18,1.00E-03,#013333,
+model,Molecular Dynamics Models,1.00E-15,1.00E-09,1.00E-30,1.00E-22,#013333,Karplus & McCammon (2002) Nat Struct Biol 9:646
+process,CO2 fixation,6.67E-02,2.38E-01,5.79E-26,1.19E-24,#006666,Bar-On et al. (2019) PNAS 116:4738 — kcat = 3-15/s natural RuBisCO; space = 0.1×–1.7× RuBisCO L8S8 enzyme volume (~7e-25 m³)
+process,Nutrient transport,1.00E-02,1.00E+00,1.00E-22,1.00E-20,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
+process,Biochemical synthesis,1.00E+00,1.00E+01,1.00E-21,1.00E-19,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
+process,Cell growth,1.00E+03,1.00E+05,1.00E-18,1.00E-14,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
+model,Community Metabolic Models,1.00E+02,1.00E+07,1.00E-18,1.00E-03,#013333,Zakem et al. (2020) ISME J 14:288
 leverage point,Community Ecology,1.00E+06,1.00E+08,1.00E-09,1.00E+00,#FF9900,Moore et al. (2013) Nature Geosci 6:701
 leverage point,Flocculation,1.00E+03,86400,1.00E-15,1.00E-09,#FF9900,Salim et al. (2011) J Appl Phycol; Vandamme et al. (2013) Biotechnol Adv 31:1680
 leverage point,Ponds,86400,3.15E+07,2000,2.00E+04,#FF9900,Design basis: 10x100x3m deep ponds (3000 m3); depth for photoinhibition protection and floc settling
-model,Biogeochemical Circulation Models,1.00E+05,1.00E+10,1.00E+09,1.00E+16,#013333,
+model,Biogeochemical Circulation Models,1.00E+05,1.00E+10,1.00E+09,1.00E+16,#013333,Levine et al. (2025) Annu Rev Earth Planet Sci 53:595
 leverage point,Sequestration,3.15E+08,1.00E+11,3.12E+09,2.91E+10,#FF9900,40 GtCO2/yr: Space_min=C as diamond (3.5 t/m3) Space_max=biomass+salt+sand (rho~1.5 t/m3) per year
-process,Extraction,3.16E+14,6.31E+15,2.03E+12,2.05E+14,#006666,Carboniferous coal (~300 Mya) + Mesozoic petroleum (~252-66 Mya); Tissot & Welte (1984)
+process,Fossil-fuel formation,3.16E+13,3.16E+15,2.03E+12,2.05E+14,#006666,Kerogen→petroleum maturation (~1-10 My) + coalification (~10-100 My); Tissot & Welte (1984)

--- a/data/datasets/desert_farm_leverage_points.csv
+++ b/data/datasets/desert_farm_leverage_points.csv
@@ -1,9 +1,9 @@
 Prefix,ShortName,Time_min,Time_max,Space_min,Space_max,Color,Reference
 model,Molecular Dynamics Models,1.00E-15,1.00E-09,1.00E-30,1.00E-22,#013333,Karplus & McCammon (2002) Nat Struct Biol 9:646
 process,CO2 fixation,6.67E-02,2.38E-01,5.79E-26,1.19E-24,#006666,Bar-On et al. (2019) PNAS 116:4738 — kcat = 3-15/s natural RuBisCO; space = 0.1×–1.7× RuBisCO L8S8 enzyme volume (~7e-25 m³)
-process,Nutrient transport,1.00E-02,1.00E+00,1.00E-22,1.00E-20,#006666,Milo & Phillips (2015) Cell Biology by the Numbers (see data/references/)
-process,Biochemical synthesis,1.00E+00,1.00E+01,1.00E-21,1.00E-19,#006666,Milo & Phillips (2015) Cell Biology by the Numbers (see data/references/)
-process,Photoautotroph cell growth,7.56E+03,1.00E+05,1.00E-18,1.00E-14,#006666,Milo & Phillips (2015) Cell Biology by the Numbers; Yu et al. (2015) Sci Rep 5:8132 (UTEX 2973 fastest) (see data/references/)
+process,Nutrient transport,1.00E-02,1.00E+00,1.00E-22,1.00E-20,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
+process,Biochemical synthesis,1.00E+00,1.00E+01,1.00E-21,1.00E-19,#006666,Milo & Phillips (2015) Cell Biology by the Numbers
+process,Photoautotroph cell growth,7.56E+03,1.00E+05,1.00E-18,1.00E-14,#006666,Milo & Phillips (2015) Cell Biology by the Numbers; Yu et al. (2015) Sci Rep 5:8132 (UTEX 2973 fastest)
 model,Community Metabolic Models,1.00E+02,1.00E+07,1.00E-18,1.00E-03,#013333,Zakem et al. (2020) ISME J 14:288
 leverage point,Community Ecology,1.00E+06,1.00E+08,1.00E-09,1.00E+00,#FF9900,Moore et al. (2013) Nature Geosci 6:701
 leverage point,Flocculation,1.00E+03,86400,1.00E-15,1.00E-09,#FF9900,Salim et al. (2011) J Appl Phycol; Vandamme et al. (2013) Biotechnol Adv 31:1680

--- a/data/references/README.md
+++ b/data/references/README.md
@@ -1,20 +1,10 @@
 # References
 
-This directory contains curated reference data backing the Stommel-diagram
-row bounds in `data/datasets/desert_farm_leverage_points.csv`.
+Standalone reference data — not coupled to any specific dataset in this repo.
 
 ## Files
 
-- `bionumbers_subset.csv` — entries from the [BioNumbers database](https://bionumbers.hms.harvard.edu/) (Milo & Phillips, *Cell Biology by the Numbers*) with stable `bion_id` identifiers.
-- `phototroph_growth_supplementary.csv` — entries from primary literature where BioNumbers has no entry or no scalar value (e.g., entries with `NaN` in the BioNumbers `Value` column).
-
-Each file uses `Cited_in_row` to map back to the row(s) in `desert_farm_leverage_points.csv` that the entry justifies.
-
-## Why a curated subset
-
-The full BioNumbers database contains ~14,300 entries (~27 MB as HTML export).
-Most are irrelevant to the desert farm Stommel diagram. Including only the
-cited subset keeps this repo lean and provides explicit per-number provenance.
+- `bionumbers_subset.csv` — curated phototroph-relevant entries from the [BioNumbers database](https://bionumbers.hms.harvard.edu/) (Milo & Phillips, *Cell Biology by the Numbers*) with stable `bion_id` identifiers and direct URLs.
 
 ## `bionumbers_subset.csv` schema
 
@@ -27,50 +17,15 @@ cited subset keeps this repo lean and provides explicit per-number provenance.
 | `Range` | Reported range (often empty) |
 | `Units` | Units of `Value` |
 | `URL` | Direct link to the BioNumbers entry |
-| `Cited_in_row` | Which `desert_farm_leverage_points.csv` row uses this entry |
 
-## `phototroph_growth_supplementary.csv` schema
+## Scope
 
-Same as above but `bion_id` replaced with a `Reference` column containing the full citation, since these entries are not in BioNumbers.
+Curated to phototroph-relevant entries (cyanobacteria, green algae, diatoms) across three categories: cell generation/doubling times, biochemical synthesis rates (transcription/translation elongation), and nutrient transport (small-molecule diffusion, transporter kinetics). Where phototroph-specific entries were unavailable, generic or model-organism data (e.g., E. coli, Xenopus) was kept as a proxy and noted in `Organism`.
 
-| Column | Description |
-|---|---|
-| `Properties` | Description of the measured quantity |
-| `Organism` | Organism the measurement is from |
-| `Value` | Reported value |
-| `Range` | Reported range (often empty) |
-| `Units` | Units of `Value` |
-| `Reference` | Full citation (author, year, journal, volume, page) |
-| `URL` | Direct link to the article (DOI preferred) |
-| `Cited_in_row` | Which `desert_farm_leverage_points.csv` row uses this entry |
-
-## Curation criteria
-
-- **Photoautotroph cell growth**: cell division/generation times for cyanobacteria, green algae, and diatoms. Excluded: heterotrophic bacteria, fungi, mammalian cells. The row `Time_min` is anchored to *Synechococcus elongatus* UTEX 2973 (the fastest known photoautotroph, ~2.1 h doubling), sourced from `phototroph_growth_supplementary.csv` since BioNumbers entry 112484 for this strain has no scalar value.
-- **Biochemical synthesis**: translation and transcription elongation rates across model organisms. Bound by time per peptide/RNA elongation event.
-- **Nutrient transport**: diffusion coefficients of small molecules (CO2, glucose, nitrate, ammonium) in water and intracellular environments, plus representative uptake rates.
-
-## Known gaps
-
-- Some BioNumbers entries with relevant `Properties` strings have `NaN` in `Value` (record exists but no scalar). These were excluded from `bionumbers_subset.csv`. Where the row's bound depends on such an entry, the data is moved to `phototroph_growth_supplementary.csv` with primary-literature citation (e.g., UTEX 2973).
-- Phototroph-specific data is sparse for some categories (e.g., transporter kinetics). Where a phototroph entry was unavailable, generic or representative organism data (E. coli, Xenopus, generic) was used as a proxy. This is documented per-entry in `Organism`.
-
-## Updating
-
-When new rows are added to `desert_farm_leverage_points.csv` that cite Milo & Phillips (or other primary literature):
-
-1. Search the full BioNumbers database for relevant entries.
-2. Add matching entries to `bionumbers_subset.csv` with the appropriate `Cited_in_row` value.
-3. If a needed value is not in BioNumbers (or has `NaN`), add a primary-literature entry to `phototroph_growth_supplementary.csv`.
-4. Avoid duplication — a single entry can be `Cited_in_row` for multiple rows by listing them semicolon-separated.
+The full BioNumbers database has ~14,300 entries (~27 MB HTML export); this is a focused subset kept as a resource for future work.
 
 ## Attribution
 
-BioNumbers is a project of the Milo Lab (Weizmann Institute) and Harvard Medical
-School. Cite as: Milo R, Jorgensen P, Moran U, Weber G, Springer M (2010).
-*BioNumbers — the database of key numbers in molecular and cell biology*.
-Nucleic Acids Res. 38:D750–D753.
-DOI: [10.1093/nar/gkp889](https://doi.org/10.1093/nar/gkp889).
+BioNumbers is a project of the Milo Lab (Weizmann Institute) and Harvard Medical School. Cite as: Milo R, Jorgensen P, Moran U, Weber G, Springer M (2010). *BioNumbers — the database of key numbers in molecular and cell biology*. Nucleic Acids Res. 38:D750–D753. DOI: [10.1093/nar/gkp889](https://doi.org/10.1093/nar/gkp889).
 
-For the broader synthesis: Milo R, Phillips R (2015). *Cell Biology by the
-Numbers*. Garland Science.
+For the broader synthesis: Milo R, Phillips R (2015). *Cell Biology by the Numbers*. Garland Science.

--- a/data/references/README.md
+++ b/data/references/README.md
@@ -1,20 +1,22 @@
 # References
 
-## BioNumbers subset — `bionumbers_subset.csv`
+This directory contains curated reference data backing the Stommel-diagram
+row bounds in `data/datasets/desert_farm_leverage_points.csv`.
 
-This file contains a curated subset of entries from the
-[BioNumbers database](https://bionumbers.hms.harvard.edu/) (Milo & Phillips,
-*Cell Biology by the Numbers*) that justify the time and space bounds for
-specific rows in `data/datasets/desert_farm_leverage_points.csv`.
+## Files
 
-### Why a subset
+- `bionumbers_subset.csv` — entries from the [BioNumbers database](https://bionumbers.hms.harvard.edu/) (Milo & Phillips, *Cell Biology by the Numbers*) with stable `bion_id` identifiers.
+- `phototroph_growth_supplementary.csv` — entries from primary literature where BioNumbers has no entry or no scalar value (e.g., entries with `NaN` in the BioNumbers `Value` column).
+
+Each file uses `Cited_in_row` to map back to the row(s) in `desert_farm_leverage_points.csv` that the entry justifies.
+
+## Why a curated subset
 
 The full BioNumbers database contains ~14,300 entries (~27 MB as HTML export).
 Most are irrelevant to the desert farm Stommel diagram. Including only the
 cited subset keeps this repo lean and provides explicit per-number provenance.
-Each entry links back to its canonical BioNumbers page via the `URL` column.
 
-### Schema
+## `bionumbers_subset.csv` schema
 
 | Column | Description |
 |---|---|
@@ -27,47 +29,47 @@ Each entry links back to its canonical BioNumbers page via the `URL` column.
 | `URL` | Direct link to the BioNumbers entry |
 | `Cited_in_row` | Which `desert_farm_leverage_points.csv` row uses this entry |
 
-### Curation criteria
+## `phototroph_growth_supplementary.csv` schema
 
-- **Cell growth**: phototroph generation/doubling times (cyanobacteria, green
-  algae, diatoms). Excluded: heterotrophic bacteria, fungi, mammalian cells.
-- **Biochemical synthesis**: translation and transcription elongation rates
-  across model organisms. Used to bound time per peptide/RNA elongation.
-- **Nutrient transport**: diffusion coefficients of small molecules (CO2,
-  glucose, nitrate, ammonium) in water and intracellular environments, plus
-  representative uptake rates.
+Same as above but `bion_id` replaced with a `Reference` column containing the full citation, since these entries are not in BioNumbers.
 
-### Known gaps and caveats
+| Column | Description |
+|---|---|
+| `Properties` | Description of the measured quantity |
+| `Organism` | Organism the measurement is from |
+| `Value` | Reported value |
+| `Range` | Reported range (often empty) |
+| `Units` | Units of `Value` |
+| `Reference` | Full citation (author, year, journal, volume, page) |
+| `URL` | Direct link to the article (DOI preferred) |
+| `Cited_in_row` | Which `desert_farm_leverage_points.csv` row uses this entry |
 
-- Several BioNumbers entries with relevant `Properties` strings have
-  `NaN` in the `Value` column (record exists but no scalar). Those were
-  excluded from this subset.
-- Phototroph-specific data is sparse for some categories (e.g., transporter
-  kinetics). Where a phototroph entry was unavailable, generic or
-  representative organism data (E. coli, Xenopus, generic) was used as a
-  proxy. This is documented per-entry in `Organism`.
-- **Cell growth Time_min mismatch**: the row's `Time_min = 1.00E+03` s
-  (~17 min) is faster than any documented phototroph cell division in this
-  subset. The fastest entry is Synechocystis PCC 6803 at 5.13 h (~1.85e4 s)
-  — about 18× slower than the lower bound. Either the row should be
-  tightened to ~1e4 s, or it should be re-scoped to include
-  cell-growth-adjacent sub-processes (ribosome biogenesis, replication
-  initiation) which can occur on shorter timescales than full division.
+## Curation criteria
 
-### Updating
+- **Photoautotroph cell growth**: cell division/generation times for cyanobacteria, green algae, and diatoms. Excluded: heterotrophic bacteria, fungi, mammalian cells. The row `Time_min` is anchored to *Synechococcus elongatus* UTEX 2973 (the fastest known photoautotroph, ~2.1 h doubling), sourced from `phototroph_growth_supplementary.csv` since BioNumbers entry 112484 for this strain has no scalar value.
+- **Biochemical synthesis**: translation and transcription elongation rates across model organisms. Bound by time per peptide/RNA elongation event.
+- **Nutrient transport**: diffusion coefficients of small molecules (CO2, glucose, nitrate, ammonium) in water and intracellular environments, plus representative uptake rates.
 
-When new rows are added to `desert_farm_leverage_points.csv` that cite
-Milo & Phillips, append matching BioNumbers entries to this subset and
-add a corresponding `Cited_in_row` value. Avoid duplication — a single
-entry can be `Cited_in_row` for multiple rows by listing them
-semicolon-separated.
+## Known gaps
 
-### Attribution
+- Some BioNumbers entries with relevant `Properties` strings have `NaN` in `Value` (record exists but no scalar). These were excluded from `bionumbers_subset.csv`. Where the row's bound depends on such an entry, the data is moved to `phototroph_growth_supplementary.csv` with primary-literature citation (e.g., UTEX 2973).
+- Phototroph-specific data is sparse for some categories (e.g., transporter kinetics). Where a phototroph entry was unavailable, generic or representative organism data (E. coli, Xenopus, generic) was used as a proxy. This is documented per-entry in `Organism`.
 
-BioNumbers is a project of the Milo Lab (Weizmann Institute) and the Harvard
-Medical School. Cite as: Milo R, Jorgensen P, Moran U, Weber G, Springer M
-(2010). *BioNumbers — the database of key numbers in molecular and cell
-biology*. Nucleic Acids Res. 38:D750–D753.
+## Updating
+
+When new rows are added to `desert_farm_leverage_points.csv` that cite Milo & Phillips (or other primary literature):
+
+1. Search the full BioNumbers database for relevant entries.
+2. Add matching entries to `bionumbers_subset.csv` with the appropriate `Cited_in_row` value.
+3. If a needed value is not in BioNumbers (or has `NaN`), add a primary-literature entry to `phototroph_growth_supplementary.csv`.
+4. Avoid duplication — a single entry can be `Cited_in_row` for multiple rows by listing them semicolon-separated.
+
+## Attribution
+
+BioNumbers is a project of the Milo Lab (Weizmann Institute) and Harvard Medical
+School. Cite as: Milo R, Jorgensen P, Moran U, Weber G, Springer M (2010).
+*BioNumbers — the database of key numbers in molecular and cell biology*.
+Nucleic Acids Res. 38:D750–D753.
 DOI: [10.1093/nar/gkp889](https://doi.org/10.1093/nar/gkp889).
 
 For the broader synthesis: Milo R, Phillips R (2015). *Cell Biology by the

--- a/data/references/README.md
+++ b/data/references/README.md
@@ -1,0 +1,74 @@
+# References
+
+## BioNumbers subset — `bionumbers_subset.csv`
+
+This file contains a curated subset of entries from the
+[BioNumbers database](https://bionumbers.hms.harvard.edu/) (Milo & Phillips,
+*Cell Biology by the Numbers*) that justify the time and space bounds for
+specific rows in `data/datasets/desert_farm_leverage_points.csv`.
+
+### Why a subset
+
+The full BioNumbers database contains ~14,300 entries (~27 MB as HTML export).
+Most are irrelevant to the desert farm Stommel diagram. Including only the
+cited subset keeps this repo lean and provides explicit per-number provenance.
+Each entry links back to its canonical BioNumbers page via the `URL` column.
+
+### Schema
+
+| Column | Description |
+|---|---|
+| `bion_id` | BioNumbers entry ID (stable identifier) |
+| `Properties` | Description of the measured quantity |
+| `Organism` | Organism the measurement is from |
+| `Value` | Reported value |
+| `Range` | Reported range (often empty) |
+| `Units` | Units of `Value` |
+| `URL` | Direct link to the BioNumbers entry |
+| `Cited_in_row` | Which `desert_farm_leverage_points.csv` row uses this entry |
+
+### Curation criteria
+
+- **Cell growth**: phototroph generation/doubling times (cyanobacteria, green
+  algae, diatoms). Excluded: heterotrophic bacteria, fungi, mammalian cells.
+- **Biochemical synthesis**: translation and transcription elongation rates
+  across model organisms. Used to bound time per peptide/RNA elongation.
+- **Nutrient transport**: diffusion coefficients of small molecules (CO2,
+  glucose, nitrate, ammonium) in water and intracellular environments, plus
+  representative uptake rates.
+
+### Known gaps and caveats
+
+- Several BioNumbers entries with relevant `Properties` strings have
+  `NaN` in the `Value` column (record exists but no scalar). Those were
+  excluded from this subset.
+- Phototroph-specific data is sparse for some categories (e.g., transporter
+  kinetics). Where a phototroph entry was unavailable, generic or
+  representative organism data (E. coli, Xenopus, generic) was used as a
+  proxy. This is documented per-entry in `Organism`.
+- **Cell growth Time_min mismatch**: the row's `Time_min = 1.00E+03` s
+  (~17 min) is faster than any documented phototroph cell division in this
+  subset. The fastest entry is Synechocystis PCC 6803 at 5.13 h (~1.85e4 s)
+  — about 18× slower than the lower bound. Either the row should be
+  tightened to ~1e4 s, or it should be re-scoped to include
+  cell-growth-adjacent sub-processes (ribosome biogenesis, replication
+  initiation) which can occur on shorter timescales than full division.
+
+### Updating
+
+When new rows are added to `desert_farm_leverage_points.csv` that cite
+Milo & Phillips, append matching BioNumbers entries to this subset and
+add a corresponding `Cited_in_row` value. Avoid duplication — a single
+entry can be `Cited_in_row` for multiple rows by listing them
+semicolon-separated.
+
+### Attribution
+
+BioNumbers is a project of the Milo Lab (Weizmann Institute) and the Harvard
+Medical School. Cite as: Milo R, Jorgensen P, Moran U, Weber G, Springer M
+(2010). *BioNumbers — the database of key numbers in molecular and cell
+biology*. Nucleic Acids Res. 38:D750–D753.
+DOI: [10.1093/nar/gkp889](https://doi.org/10.1093/nar/gkp889).
+
+For the broader synthesis: Milo R, Phillips R (2015). *Cell Biology by the
+Numbers*. Garland Science.

--- a/data/references/bionumbers_subset.csv
+++ b/data/references/bionumbers_subset.csv
@@ -1,26 +1,26 @@
-bion_id,Properties,Organism,Value,Range,Units,URL,Cited_in_row
-100289,Generation time,Cyanobacteria Synechocystis PCC 6803,6.0,,Hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100289,Photoautotroph cell growth
-102211,Mean generation time (on acetate),Green algae chlorella,20.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102211,Photoautotroph cell growth
-102212,mean generation time (photoautotrophic growth),Green algae chlorella,11.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102212,Photoautotroph cell growth
-104195,Generation time,Diatom Phaeodactylum tricornutum,15.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104195,Photoautotroph cell growth
-104196,Generation time,Green algae Dunaliella tertiolecta,15.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104196,Photoautotroph cell growth
-105638,Generation time at 30°C,Green algae Dunaliella salina,20.0,,Hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=105638,Photoautotroph cell growth
-111252,Doubling time,Cyanobacteria Synechocystis PCC 6803,12.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=111252,Photoautotroph cell growth
-111335,Fastest generation time,Cyanobacteria Synechocystis PCC 6803,5.13,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=111335,Photoautotroph cell growth
-100233,Translation rate of beta-galactosidase in E. coli,Bacteria Escherichia coli,14.5,'13-16,aa/s,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100233,Biochemical synthesis
-105067,Translation rate for short peptides,Bacteria Escherichia coli,22.0,'Table link - http://bionumbers.hms.harvard.edu/files/Maximal%20translation%20rate.pdf,1/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=105067,Biochemical synthesis
-104300,Translation rate on culture of nitrogen bases and glucose,Budding yeast Saccharomyces cerevisiae,9.3,,aa/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104300,Biochemical synthesis
-104598,Translation rate,Human Homo sapiens,5.0,,aa/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104598,Biochemical synthesis
-100060,RNA polymerase transcription rate of stable RNA,Bacteria Escherichia coli,85.0,'Table link - http://bionumbers.hms.harvard.edu/files/Parameters%20pertaining%20to%20the%20macromolecular%20synthesis%20rates%20in%20exponentially%20growing%20E.%20coli%20Br%20as%20a%20function%20of%20growth%20rate%20at%2037%20degrees%20celsius.pdf,nt/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100060,Biochemical synthesis
-101904,Transcription elongation rate of rRNA operons,Bacteria Escherichia coli,42.0,'±2,nucleotides/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=101904,Biochemical synthesis
-100664,Single molecule RNA polymerase II transcription rates,Bacteria Escherichia coli,12.8,'±4.9,nucleotides/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100664,Biochemical synthesis
-100662,Maximum RNA polymerase II transcription elongation rate,Mammalian tissue culture cell,71.6,,nucleotides/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100662,Biochemical synthesis
-104089,Diffusion coefficient of glucose in water,Generic,600.0,'Table link - http://bionumbers.hms.harvard.edu/files/Diffusion%20coefficients%20of%20various%20substances%20in%20Water.pdf,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104089,Nutrient transport
-104437,Diffusion coefficient of ammonium in water,Generic,1860.0,'Table link - http://bionumbers.hms.harvard.edu/files/Biofilm%20model%20parameters.pdf,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104437,Nutrient transport
-104439,Diffusion coefficient of nitrate in water,Generic,1700.0,'Table link - http://bionumbers.hms.harvard.edu/files/Biofilm%20model%20parameters.pdf,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104439,Nutrient transport
-109504,Diffusion coefficient glucose in water at 25°C,Generic,673.0,,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=109504,Nutrient transport
-110618,Diffusion coefficient of CO2 in red blood cell,Human Homo sapiens,650.0,,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=110618,Nutrient transport
-117305,Diffusion coefficient of CO2 in air,air,1.4e-05,,m2/s,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=117305,Nutrient transport
-102428,Intracellular diffusion coefficient for glucose transporter,African clawed frog Xenopus laevis,100.0,,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102428,Nutrient transport
-109673,Highest glucose uptake rate that still allows the maximal NADH formation rate,Bacteria Escherichia coli,2.4,,mmol/(gCDW·h),https://bionumbers.hms.harvard.edu/bionumber.aspx?id=109673,Nutrient transport
-109686,Glucose uptake rate of strain C-3000 in minimal M9 media,Bacteria Escherichia coli,12.0,'±0.5,mmol/gDW/h,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=109686,Nutrient transport
+bion_id,Properties,Organism,Value,Range,Units,URL
+100289,Generation time,Cyanobacteria Synechocystis PCC 6803,6.0,,Hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100289
+102211,Mean generation time (on acetate),Green algae chlorella,20.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102211
+102212,mean generation time (photoautotrophic growth),Green algae chlorella,11.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102212
+104195,Generation time,Diatom Phaeodactylum tricornutum,15.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104195
+104196,Generation time,Green algae Dunaliella tertiolecta,15.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104196
+105638,Generation time at 30°C,Green algae Dunaliella salina,20.0,,Hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=105638
+111252,Doubling time,Cyanobacteria Synechocystis PCC 6803,12.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=111252
+111335,Fastest generation time,Cyanobacteria Synechocystis PCC 6803,5.13,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=111335
+100233,Translation rate of beta-galactosidase in E. coli,Bacteria Escherichia coli,14.5,'13-16,aa/s,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100233
+105067,Translation rate for short peptides,Bacteria Escherichia coli,22.0,'Table link - http://bionumbers.hms.harvard.edu/files/Maximal%20translation%20rate.pdf,1/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=105067
+104300,Translation rate on culture of nitrogen bases and glucose,Budding yeast Saccharomyces cerevisiae,9.3,,aa/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104300
+104598,Translation rate,Human Homo sapiens,5.0,,aa/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104598
+100060,RNA polymerase transcription rate of stable RNA,Bacteria Escherichia coli,85.0,'Table link - http://bionumbers.hms.harvard.edu/files/Parameters%20pertaining%20to%20the%20macromolecular%20synthesis%20rates%20in%20exponentially%20growing%20E.%20coli%20Br%20as%20a%20function%20of%20growth%20rate%20at%2037%20degrees%20celsius.pdf,nt/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100060
+101904,Transcription elongation rate of rRNA operons,Bacteria Escherichia coli,42.0,'±2,nucleotides/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=101904
+100664,Single molecule RNA polymerase II transcription rates,Bacteria Escherichia coli,12.8,'±4.9,nucleotides/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100664
+100662,Maximum RNA polymerase II transcription elongation rate,Mammalian tissue culture cell,71.6,,nucleotides/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100662
+104089,Diffusion coefficient of glucose in water,Generic,600.0,'Table link - http://bionumbers.hms.harvard.edu/files/Diffusion%20coefficients%20of%20various%20substances%20in%20Water.pdf,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104089
+104437,Diffusion coefficient of ammonium in water,Generic,1860.0,'Table link - http://bionumbers.hms.harvard.edu/files/Biofilm%20model%20parameters.pdf,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104437
+104439,Diffusion coefficient of nitrate in water,Generic,1700.0,'Table link - http://bionumbers.hms.harvard.edu/files/Biofilm%20model%20parameters.pdf,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104439
+109504,Diffusion coefficient glucose in water at 25°C,Generic,673.0,,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=109504
+110618,Diffusion coefficient of CO2 in red blood cell,Human Homo sapiens,650.0,,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=110618
+117305,Diffusion coefficient of CO2 in air,air,1.4e-05,,m2/s,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=117305
+102428,Intracellular diffusion coefficient for glucose transporter,African clawed frog Xenopus laevis,100.0,,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102428
+109673,Highest glucose uptake rate that still allows the maximal NADH formation rate,Bacteria Escherichia coli,2.4,,mmol/(gCDW·h),https://bionumbers.hms.harvard.edu/bionumber.aspx?id=109673
+109686,Glucose uptake rate of strain C-3000 in minimal M9 media,Bacteria Escherichia coli,12.0,'±0.5,mmol/gDW/h,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=109686

--- a/data/references/bionumbers_subset.csv
+++ b/data/references/bionumbers_subset.csv
@@ -1,0 +1,26 @@
+bion_id,Properties,Organism,Value,Range,Units,URL,Cited_in_row
+100289,Generation time,Cyanobacteria Synechocystis PCC 6803,6.0,,Hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100289,Cell growth
+102211,Mean generation time (on acetate),Green algae chlorella,20.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102211,Cell growth
+102212,mean generation time (photoautotrophic growth),Green algae chlorella,11.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102212,Cell growth
+104195,Generation time,Diatom Phaeodactylum tricornutum,15.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104195,Cell growth
+104196,Generation time,Green algae Dunaliella tertiolecta,15.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104196,Cell growth
+105638,Generation time at 30°C,Green algae Dunaliella salina,20.0,,Hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=105638,Cell growth
+111252,Doubling time,Cyanobacteria Synechocystis PCC 6803,12.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=111252,Cell growth
+111335,Fastest generation time,Cyanobacteria Synechocystis PCC 6803,5.13,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=111335,Cell growth
+100233,Translation rate of beta-galactosidase in E. coli,Bacteria Escherichia coli,14.5,'13-16,aa/s,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100233,Biochemical synthesis
+105067,Translation rate for short peptides,Bacteria Escherichia coli,22.0,'Table link - http://bionumbers.hms.harvard.edu/files/Maximal%20translation%20rate.pdf,1/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=105067,Biochemical synthesis
+104300,Translation rate on culture of nitrogen bases and glucose,Budding yeast Saccharomyces cerevisiae,9.3,,aa/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104300,Biochemical synthesis
+104598,Translation rate,Human Homo sapiens,5.0,,aa/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104598,Biochemical synthesis
+100060,RNA polymerase transcription rate of stable RNA,Bacteria Escherichia coli,85.0,'Table link - http://bionumbers.hms.harvard.edu/files/Parameters%20pertaining%20to%20the%20macromolecular%20synthesis%20rates%20in%20exponentially%20growing%20E.%20coli%20Br%20as%20a%20function%20of%20growth%20rate%20at%2037%20degrees%20celsius.pdf,nt/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100060,Biochemical synthesis
+101904,Transcription elongation rate of rRNA operons,Bacteria Escherichia coli,42.0,'±2,nucleotides/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=101904,Biochemical synthesis
+100664,Single molecule RNA polymerase II transcription rates,Bacteria Escherichia coli,12.8,'±4.9,nucleotides/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100664,Biochemical synthesis
+100662,Maximum RNA polymerase II transcription elongation rate,Mammalian tissue culture cell,71.6,,nucleotides/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100662,Biochemical synthesis
+104089,Diffusion coefficient of glucose in water,Generic,600.0,'Table link - http://bionumbers.hms.harvard.edu/files/Diffusion%20coefficients%20of%20various%20substances%20in%20Water.pdf,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104089,Nutrient transport
+104437,Diffusion coefficient of ammonium in water,Generic,1860.0,'Table link - http://bionumbers.hms.harvard.edu/files/Biofilm%20model%20parameters.pdf,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104437,Nutrient transport
+104439,Diffusion coefficient of nitrate in water,Generic,1700.0,'Table link - http://bionumbers.hms.harvard.edu/files/Biofilm%20model%20parameters.pdf,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104439,Nutrient transport
+109504,Diffusion coefficient glucose in water at 25°C,Generic,673.0,,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=109504,Nutrient transport
+110618,Diffusion coefficient of CO2 in red blood cell,Human Homo sapiens,650.0,,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=110618,Nutrient transport
+117305,Diffusion coefficient of CO2 in air,air,1.4e-05,,m2/s,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=117305,Nutrient transport
+102428,Intracellular diffusion coefficient for glucose transporter,African clawed frog Xenopus laevis,100.0,,µm^2/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102428,Nutrient transport
+109673,Highest glucose uptake rate that still allows the maximal NADH formation rate,Bacteria Escherichia coli,2.4,,mmol/(gCDW·h),https://bionumbers.hms.harvard.edu/bionumber.aspx?id=109673,Nutrient transport
+109686,Glucose uptake rate of strain C-3000 in minimal M9 media,Bacteria Escherichia coli,12.0,'±0.5,mmol/gDW/h,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=109686,Nutrient transport

--- a/data/references/bionumbers_subset.csv
+++ b/data/references/bionumbers_subset.csv
@@ -1,12 +1,12 @@
 bion_id,Properties,Organism,Value,Range,Units,URL,Cited_in_row
-100289,Generation time,Cyanobacteria Synechocystis PCC 6803,6.0,,Hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100289,Cell growth
-102211,Mean generation time (on acetate),Green algae chlorella,20.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102211,Cell growth
-102212,mean generation time (photoautotrophic growth),Green algae chlorella,11.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102212,Cell growth
-104195,Generation time,Diatom Phaeodactylum tricornutum,15.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104195,Cell growth
-104196,Generation time,Green algae Dunaliella tertiolecta,15.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104196,Cell growth
-105638,Generation time at 30°C,Green algae Dunaliella salina,20.0,,Hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=105638,Cell growth
-111252,Doubling time,Cyanobacteria Synechocystis PCC 6803,12.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=111252,Cell growth
-111335,Fastest generation time,Cyanobacteria Synechocystis PCC 6803,5.13,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=111335,Cell growth
+100289,Generation time,Cyanobacteria Synechocystis PCC 6803,6.0,,Hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100289,Photoautotroph cell growth
+102211,Mean generation time (on acetate),Green algae chlorella,20.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102211,Photoautotroph cell growth
+102212,mean generation time (photoautotrophic growth),Green algae chlorella,11.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=102212,Photoautotroph cell growth
+104195,Generation time,Diatom Phaeodactylum tricornutum,15.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104195,Photoautotroph cell growth
+104196,Generation time,Green algae Dunaliella tertiolecta,15.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104196,Photoautotroph cell growth
+105638,Generation time at 30°C,Green algae Dunaliella salina,20.0,,Hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=105638,Photoautotroph cell growth
+111252,Doubling time,Cyanobacteria Synechocystis PCC 6803,12.0,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=111252,Photoautotroph cell growth
+111335,Fastest generation time,Cyanobacteria Synechocystis PCC 6803,5.13,,hours,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=111335,Photoautotroph cell growth
 100233,Translation rate of beta-galactosidase in E. coli,Bacteria Escherichia coli,14.5,'13-16,aa/s,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=100233,Biochemical synthesis
 105067,Translation rate for short peptides,Bacteria Escherichia coli,22.0,'Table link - http://bionumbers.hms.harvard.edu/files/Maximal%20translation%20rate.pdf,1/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=105067,Biochemical synthesis
 104300,Translation rate on culture of nitrogen bases and glucose,Budding yeast Saccharomyces cerevisiae,9.3,,aa/sec,https://bionumbers.hms.harvard.edu/bionumber.aspx?id=104300,Biochemical synthesis

--- a/data/references/phototroph_growth_supplementary.csv
+++ b/data/references/phototroph_growth_supplementary.csv
@@ -1,2 +1,0 @@
-Properties,Organism,Value,Range,Units,Reference,URL,Cited_in_row
-Doubling time under high light and high CO2 (38°C; 1500 µmol photons/m²/s; 5% CO2),Cyanobacteria Synechococcus elongatus UTEX 2973,2.1,,hours,Yu et al. (2015) Sci Rep 5:8132,https://doi.org/10.1038/srep08132,Photoautotroph cell growth

--- a/data/references/phototroph_growth_supplementary.csv
+++ b/data/references/phototroph_growth_supplementary.csv
@@ -1,0 +1,2 @@
+Properties,Organism,Value,Range,Units,Reference,URL,Cited_in_row
+Doubling time under high light and high CO2 (38°C; 1500 µmol photons/m²/s; 5% CO2),Cyanobacteria Synechococcus elongatus UTEX 2973,2.1,,hours,Yu et al. (2015) Sci Rep 5:8132,https://doi.org/10.1038/srep08132,Photoautotroph cell growth


### PR DESCRIPTION
Resolves R1–R8 data concerns + adds a standalone curated BioNumbers subset.

Supersedes #25 (which fell behind main during the BioNumbers addition; rebuilt fresh from current main per branch-hygiene rule).

## Changes to `data/datasets/desert_farm_leverage_points.csv`

| ID | Row | Change |
|---|---|---|
| R1 | CO2 fixation | `Time_min` 7.69e-3 → 6.67e-2 (Bar-On natural RuBisCO kcat ceiling, 15/s) |
| R2 | Nutrient transport, Biochemical synthesis, Photoautotroph cell growth | Replace Moore et al. (2013) mis-citation with Milo & Phillips (2015) *Cell Biology by the Numbers* |
| R3 | Growth → **Photoautotroph cell growth** | Tighten to single algal cell scope: Time 7.56e3–1e5 s (Time_min anchored to *Synechococcus elongatus* UTEX 2973, 2.1 h doubling per Yu et al. 2015 *Sci Rep* 5:8132), Space 1e-18 to 1e-14 m³. Population scales remain in `Community Ecology` |
| R4 | Molecular Dynamics Models | `Space_max` 1e-27 → 1e-22 m³ (modern atomistic MD reaches 100-nm boxes) |
| R5 | Community Metabolic Models | `Time_min` `99` → `1.00E+02` |
| R6 | Three model rows | Fill empty References (Karplus & McCammon 2002 / Zakem et al. 2020 *ISME J* / Levine et al. 2025 *Annu Rev Earth Planet Sci*) |
| R7 | Extraction → **Fossil-fuel formation** | Time reflects formation duration (~1–100 My) not deposit age |
| R8 | CO2 fixation | Extend Reference text to justify both time and space bounds; drop Igamberdiev (2015) CA reference (not load-bearing once Time_min reflects intrinsic RuBisCO kcat) |

## New: `data/references/` (standalone resource)

Curated phototroph reference data, not coupled to the main CSV — kept as a resource for future work.

- `bionumbers_subset.csv` — 25 entries from the BioNumbers database with stable `bion_id` identifiers and direct URLs. Phototroph-relevant (cyanobacteria, green algae, diatoms) across cell generation/doubling times, biochemical synthesis rates (transcription/translation elongation), and small-molecule diffusion / transporter kinetics. Generic-organism proxies (e.g., *E. coli*, *Xenopus*) used where phototroph-specific entries were unavailable; flagged per-row in `Organism`.
- `README.md` — schema, scope, attribution.
