### PR TITLE
fix(test): move test_local_install legend back to right side

### DIFF
--- a/tests/test_local_install.py
+++ b/tests/test_local_install.py
@@ -82,7 +82,7 @@ def main():
     p = add_magnitude_labels(p, font_size="10pt", space_on_x=False)
     p = add_diffusion_lines(p, space_on_x=False)
     p = add_predefined_processes(p, transformed, interactive=False, font_size="9pt", space_on_x=False)
-    p = add_legend(p, position="above", font_size="9pt")
+    p = add_legend(p, position="right", font_size="9pt")
     print("Built Stommel diagram OK")
 
     # ── Save embeddable HTML ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
One-line fix: change `add_legend(p, position="above", ...)` → `position="right"` in `tests/test_local_install.py`.

This script is run by `make test-package` and produces `test_stommel.html` — the canonical embeddable demo of the package post-install. With the legend above the plot, the legend column compressed the plot vertically; moving it back to the right keeps it outside the plot area in a vertical column.

## Files changed
- `tests/test_local_install.py` (1 line)

## Verified
- black + flake8 clean
- No other call sites of `add_legend(..., position="above")` in the repo

## Replaces
Closed PR #29, which mistakenly added a separate `docs/build_demo_boyd.py` instead of fixing the existing demo. This is the actual fix.
